### PR TITLE
feat: unified Entity with children, components, rotation, and world position

### DIFF
--- a/SkiaSharpGames.slnx
+++ b/SkiaSharpGames.slnx
@@ -27,6 +27,9 @@
   <Folder Name="/src/Catch/">
     <Project Path="src/Catch/SkiaSharpGames.Catch.csproj" />
   </Folder>
+  <Folder Name="/src/LunarLander/">
+    <Project Path="src/LunarLander/SkiaSharpGames.LunarLander.csproj" />
+  </Folder>
   <Folder Name="/tests/" />
   <Folder Name="/tests/GameEngine.Tests/">
     <Project Path="tests/GameEngine.Tests/SkiaSharpGames.GameEngine.Tests.csproj" />

--- a/src/BlazorApp/Pages/Games/LunarLander.razor
+++ b/src/BlazorApp/Pages/Games/LunarLander.razor
@@ -1,0 +1,15 @@
+@page "/games/lunar-lander"
+@layout GameLayout
+
+<PageTitle>Lunar Lander – SkiaSharp Games</PageTitle>
+
+<GameView Game="_game" />
+
+@code {
+    private readonly Game _game;
+
+    public LunarLander([FromKeyedServices("lunar-lander")] Game game)
+    {
+        _game = game;
+    }
+}

--- a/src/BlazorApp/Pages/Home.razor
+++ b/src/BlazorApp/Pages/Home.razor
@@ -78,4 +78,14 @@
             <span class="game-card-play">▶ Play</span>
         </div>
     </a>
+    <a class="game-card" href="games/lunar-lander">
+        <div class="game-card-banner">
+            <span class="game-card-emoji">🚀</span>
+        </div>
+        <div class="game-card-info">
+            <h2 class="game-card-title">Lunar Lander</h2>
+            <p class="game-card-desc">Guide your lander safely to the pad. Use thrust and rotation to control descent — land gently or crash!</p>
+            <span class="game-card-play">▶ Play</span>
+        </div>
+    </a>
 </div>

--- a/src/BlazorApp/Program.cs
+++ b/src/BlazorApp/Program.cs
@@ -8,6 +8,7 @@ using SkiaSharpGames.Pong;
 using SkiaSharpGames.TwoZeroFourEight;
 using SkiaSharpGames.SpaceInvaders;
 using SkiaSharpGames.Catch;
+using SkiaSharpGames.LunarLander;
 using SkiaSharpGames.GameEngine;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -25,5 +26,6 @@ builder.Services.AddKeyedTransient<Game>("pong", (sp, _) => PongGame.Create());
 builder.Services.AddKeyedTransient<Game>("2048", (sp, _) => TwoZeroFourEightGame.Create());
 builder.Services.AddKeyedTransient<Game>("space-invaders", (sp, _) => SpaceInvadersGame.Create());
 builder.Services.AddKeyedTransient<Game>("catch", (sp, _) => CatchGame.Create());
+builder.Services.AddKeyedTransient<Game>("lunar-lander", (sp, _) => LunarLanderGame.Create());
 
 await builder.Build().RunAsync();

--- a/src/BlazorApp/SkiaSharpGames.BlazorApp.csproj
+++ b/src/BlazorApp/SkiaSharpGames.BlazorApp.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\TwoZeroFourEight\SkiaSharpGames.TwoZeroFourEight.csproj" />
     <ProjectReference Include="..\SpaceInvaders\SkiaSharpGames.SpaceInvaders.csproj" />
     <ProjectReference Include="..\Catch\SkiaSharpGames.Catch.csproj" />
+    <ProjectReference Include="..\LunarLander\SkiaSharpGames.LunarLander.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Breakout/Ball.cs
+++ b/src/Breakout/Ball.cs
@@ -8,7 +8,14 @@ namespace SkiaSharpGames.Breakout;
 /// </summary>
 internal sealed class Ball : Entity
 {
-    public readonly CircleCollider Collider = new() { Radius = BallRadius };
-    public readonly Rigidbody2D Rigidbody = new();
-    public readonly BallSprite Sprite = new();
+    public Ball()
+    {
+        Collider = new CircleCollider { Radius = BallRadius };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new BallSprite();
+    }
+
+    public new BallSprite Sprite { get => (BallSprite)base.Sprite!; init => base.Sprite = value; }
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 }

--- a/src/Breakout/BallSprite.cs
+++ b/src/Breakout/BallSprite.cs
@@ -18,7 +18,7 @@ internal sealed class BallSprite : Sprite
 
     public SKColor GlowColor { get; set; } = SKColors.White;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
@@ -27,11 +27,11 @@ internal sealed class BallSprite : Sprite
         {
             EnsureGlowMask();
             _glowPaint.Color = GlowColor.WithAlpha((byte)(60 * Alpha));
-            canvas.DrawCircle(x, y, Radius + GlowRadius / 2f, _glowPaint);
+            canvas.DrawCircle(0, 0, Radius + GlowRadius / 2f, _glowPaint);
         }
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
-        canvas.DrawCircle(x, y, Radius, _paint);
+        canvas.DrawCircle(0, 0, Radius, _paint);
     }
 
     private void EnsureGlowMask()

--- a/src/Breakout/BreakoutConstants.cs
+++ b/src/Breakout/BreakoutConstants.cs
@@ -13,6 +13,7 @@ internal static class BreakoutConstants
     public const float DefaultPaddleWidth = 100f;
     public const float PaddleHeight = 14f;
     public const float PaddleY = 558f;
+    public const float PaddleSpeed = 500f;
     public const float BigPaddleMultiplier = 1.8f;
     public const float BigPaddleDuration = 8f;
 

--- a/src/Breakout/Brick.cs
+++ b/src/Breakout/Brick.cs
@@ -6,27 +6,18 @@ namespace SkiaSharpGames.Breakout;
 internal sealed class Brick : Entity
 {
     public readonly int Row, Col;
-    public readonly RectCollider Collider = new()
-    {
-        Width = BrickWidth,
-        Height = BrickHeight,
-    };
-    public readonly BrickSprite Sprite = new()
-    {
-        Width = BrickWidth,
-        Height = BrickHeight,
-    };
 
-    /// <param name="row">Row index.</param>
-    /// <param name="col">Column index.</param>
-    /// <param name="cx">Centre X in game-space units.</param>
-    /// <param name="cy">Centre Y in game-space units.</param>
     public Brick(int row, int col, float cx, float cy)
     {
         Row = row;
         Col = col;
         X = cx;
         Y = cy;
+        Collider = new RectCollider { Width = BrickWidth, Height = BrickHeight };
+        Sprite = new BrickSprite { Width = BrickWidth, Height = BrickHeight };
     }
+
+    public new BrickSprite Sprite { get => (BrickSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
 }
 

--- a/src/Breakout/BrickSprite.cs
+++ b/src/Breakout/BrickSprite.cs
@@ -20,13 +20,13 @@ internal sealed class BrickSprite : Sprite
 
     public override void Update(float deltaTime) => Shimmer.Update(deltaTime);
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
 
-        float left = x - Width / 2f;
-        float top = y - Height / 2f;
+        float left = 0 - Width / 2f;
+        float top = 0 - Height / 2f;
         var rect = SKRect.Create(left, top, Width, Height);
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));

--- a/src/Breakout/FallingPowerUp.cs
+++ b/src/Breakout/FallingPowerUp.cs
@@ -6,15 +6,15 @@ namespace SkiaSharpGames.Breakout;
 internal sealed class FallingPowerUp : Entity
 {
     public PowerUpType Type;
-    public readonly Rigidbody2D Rigidbody = new() { VelocityY = PowerUpSpeed };
-    public readonly RectCollider Collider = new()
+
+    public FallingPowerUp()
     {
-        Width = PowerUpW,
-        Height = PowerUpH,
-    };
-    public readonly PowerUpSprite Sprite = new()
-    {
-        Width = PowerUpW,
-        Height = PowerUpH,
-    };
+        Rigidbody = new Rigidbody2D { VelocityY = PowerUpSpeed };
+        Collider = new RectCollider { Width = PowerUpW, Height = PowerUpH };
+        Sprite = new PowerUpSprite { Width = PowerUpW, Height = PowerUpH };
+    }
+
+    public new PowerUpSprite Sprite { get => (PowerUpSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 }

--- a/src/Breakout/GameOverScreen.cs
+++ b/src/Breakout/GameOverScreen.cs
@@ -20,10 +20,10 @@ internal sealed class GameOverScreen(BreakoutGameState state, IScreenCoordinator
     {
         canvas.DrawRect(0, 0, GameWidth, GameHeight, _overlayPaint);
 
-        _titleText.Draw(canvas, GameWidth / 2f, 270f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 270f); _titleText.Draw(canvas); canvas.Restore();
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 335f);
-        _promptText.Draw(canvas, GameWidth / 2f, 395f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 335f); _scoreText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 395f); _promptText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y)

--- a/src/Breakout/Paddle.cs
+++ b/src/Breakout/Paddle.cs
@@ -11,19 +11,20 @@ internal sealed class Paddle : Entity
 {
     private readonly AnimatedFloat _width = new(DefaultPaddleWidth);
 
+    public Paddle()
+    {
+        Collider = new RectCollider { Height = PaddleHeight };
+        Sprite = new PaddleSprite();
+    }
+
     /// <summary>Current animated width of the paddle.</summary>
     public float Width => _width.Value;
 
     /// <summary>True while a width animation is in progress.</summary>
     public bool IsWidthAnimating => _width.IsAnimating;
 
-    /// <summary>Advances the width animation and keeps the collider and sprite in sync.</summary>
-    public void Update(float deltaTime)
-    {
-        _width.Update(deltaTime);
-        Collider.Width = _width.Value;
-        Sprite.Width = _width.Value;
-    }
+    public new PaddleSprite Sprite { get => (PaddleSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
 
     /// <summary>Animates the paddle to a new width.</summary>
     public void AnimateWidth(float target, float duration, Func<float, float> easing) =>
@@ -37,11 +38,10 @@ internal sealed class Paddle : Entity
         Sprite.Width = value;
     }
 
-    /// <summary>
-    /// Collider.Width is kept in sync by <see cref="Update"/> and <see cref="SetWidthImmediate"/>.
-    /// Never patch it externally.
-    /// </summary>
-    public readonly RectCollider Collider = new() { Height = PaddleHeight };
-
-    public readonly PaddleSprite Sprite = new();
+    protected override void OnUpdate(float deltaTime)
+    {
+        _width.Update(deltaTime);
+        Collider.Width = _width.Value;
+        Sprite.Width = _width.Value;
+    }
 }

--- a/src/Breakout/PaddleSprite.cs
+++ b/src/Breakout/PaddleSprite.cs
@@ -16,14 +16,14 @@ internal sealed class PaddleSprite : Sprite
 
     public float CornerRadius { get; set; } = 6f;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
         canvas.DrawRoundRect(
-            new SKRoundRect(SKRect.Create(x - Width / 2f, y - Height / 2f, Width, Height), CornerRadius),
+            new SKRoundRect(SKRect.Create(0 - Width / 2f, 0 - Height / 2f, Width, Height), CornerRadius),
             _paint);
     }
 }

--- a/src/Breakout/PlayScreen.cs
+++ b/src/Breakout/PlayScreen.cs
@@ -115,12 +115,12 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         // Boundary wall collisions (left, top, right bounce; bottom = life lost)
         foreach (var wall in (ReadOnlySpan<Wall>)[_leftWall, _topWall, _rightWall])
         {
-            if (CollisionResolver.TryGetHit(_ball, _ball.Collider, wall, wall.Collider, out var wallHit))
+            if (CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, wall.X, wall.Y, wall.Collider, out var wallHit))
                 _ball.Rigidbody.Bounce(wallHit);
         }
 
         // Ball hit the bottom wall — lose a life
-        if (CollisionResolver.Overlaps(_ball, _ball.Collider, _bottomWall, _bottomWall.Collider))
+        if (CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _bottomWall.X, _bottomWall.Y, _bottomWall.Collider, out _))
         {
             state.Lives--;
             if (state.Lives <= 0)
@@ -146,7 +146,7 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
     private void ResolvePaddleCollision()
     {
         if (_ball.Rigidbody.VelocityY > 0f &&
-            CollisionResolver.TryGetHit(_ball, _ball.Collider, _paddle, _paddle.Collider, out var hit))
+            CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _paddle.X, _paddle.Y, _paddle.Collider, out var hit))
         {
             // Push the ball out of the paddle so it cannot oscillate inside it.
             _ball.X += hit.NormalX * hit.Penetration;
@@ -168,7 +168,7 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         foreach (var brick in _bricks)
         {
             if (!brick.Active ||
-                !CollisionResolver.TryGetHit(_ball, _ball.Collider, brick, brick.Collider, out var hit))
+                !CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, brick.X, brick.Y, brick.Collider, out var hit))
                 continue;
 
             brick.Active = false;
@@ -246,47 +246,47 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         {
             if (!brick.Active) continue;
             brick.Sprite.Alpha = 1f;
-            brick.Sprite.Draw(canvas, brick.X, brick.Y);
+            canvas.Save(); canvas.Translate(brick.X, brick.Y); brick.Sprite.Draw(canvas); canvas.Restore();
         }
 
         // Falling power-ups
         foreach (var pu in _powerUps)
         {
-            pu.Sprite.Draw(canvas, pu.X, pu.Y);
+            canvas.Save(); canvas.Translate(pu.X, pu.Y); pu.Sprite.Draw(canvas); canvas.Restore();
             _powerUpLabel.Text = pu.Type == PowerUpType.StrongBall ? "S" : "B";
-            _powerUpLabel.Draw(canvas, pu.X, pu.Y + 4f);
+            canvas.Save(); canvas.Translate(pu.X, pu.Y + 4f); _powerUpLabel.Draw(canvas); canvas.Restore();
         }
 
         // Paddle
         _paddle.Sprite.Color = _bigPaddleTimer.Active || _paddle.IsWidthAnimating
             ? BigPaddleColor : PaddleColor;
-        _paddle.Sprite.Draw(canvas, _paddle.X, _paddle.Y);
+        canvas.Save(); canvas.Translate(_paddle.X, _paddle.Y); _paddle.Sprite.Draw(canvas); canvas.Restore();
 
         // Ball
         _ball.Sprite.Color = _strongBallTimer.Active ? StrongBallColor : SKColors.White;
         _ball.Sprite.GlowColor = _strongBallTimer.Active ? StrongBallColor : SKColors.White;
-        _ball.Sprite.Draw(canvas, _ball.X, _ball.Y);
+        canvas.Save(); canvas.Translate(_ball.X, _ball.Y); _ball.Sprite.Draw(canvas); canvas.Restore();
 
         // HUD
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, 20f, 30f);
+        canvas.Save(); canvas.Translate(20f, 30f); _scoreText.Draw(canvas); canvas.Restore();
 
         _livesText.Text = $"Lives: {state.Lives}";
-        _livesText.Draw(canvas, GameWidth - 20f, 30f);
+        canvas.Save(); canvas.Translate(GameWidth - 20f, 30f); _livesText.Draw(canvas); canvas.Restore();
 
         float hudY = 52f;
         if (_strongBallTimer.Active)
         {
             _strongBallText.Text = $"STRONG BALL {_strongBallTimer.Remaining:F1}s";
             _strongBallText.Color = StrongBallColor;
-            _strongBallText.Draw(canvas, GameWidth / 2f, hudY);
+            canvas.Save(); canvas.Translate(GameWidth / 2f, hudY); _strongBallText.Draw(canvas); canvas.Restore();
             hudY += 18f;
         }
         if (_bigPaddleTimer.Active)
         {
             _bigPaddleText.Text = $"BIG PADDLE {_bigPaddleTimer.Remaining:F1}s";
             _bigPaddleText.Color = BigPaddleColor;
-            _bigPaddleText.Draw(canvas, GameWidth / 2f, hudY);
+            canvas.Save(); canvas.Translate(GameWidth / 2f, hudY); _bigPaddleText.Draw(canvas); canvas.Restore();
         }
     }
 }

--- a/src/Breakout/PlayScreen.cs
+++ b/src/Breakout/PlayScreen.cs
@@ -22,8 +22,9 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
     private CountdownTimer _strongBallTimer;
     private CountdownTimer _bigPaddleTimer;
 
-    private readonly List<Brick> _bricks = [];
-    private readonly List<FallingPowerUp> _powerUps = [];
+    // ── Entity groups (parenting) ─────────────────────────────────────────
+    private readonly Entity _bricks = new();
+    private readonly Entity _powerUps = new();
 
     // ── Text sprites ──────────────────────────────────────────────────────
     private readonly TextSprite _scoreText = new() { Size = 20f, Color = SKColors.White };
@@ -38,7 +39,11 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         state.Lives = 3;
         _strongBallTimer = default;
         _bigPaddleTimer = default;
-        _powerUps.Clear();
+
+        // Clear and rebuild power-ups
+        foreach (var child in _powerUps.Children.ToArray())
+            _powerUps.RemoveChild(child);
+
         InitBricks();
         _paddle.X = GameWidth / 2f;
         _paddle.Y = PaddleY + PaddleHeight / 2f;
@@ -48,8 +53,6 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
 
     public override void OnActivated()
     {
-        // The transition is complete — re-sync the ball to wherever the paddle actually is.
-        // Pointer events during the dissolve-in may have moved the paddle while Update was paused.
         ResetBall();
     }
 
@@ -57,7 +60,10 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
 
     private void InitBricks()
     {
-        _bricks.Clear();
+        // Remove all existing brick children
+        foreach (var child in _bricks.Children.ToArray())
+            _bricks.RemoveChild(child);
+
         for (int r = 0; r < BrickRows; r++)
         {
             for (int c = 0; c < BrickCols; c++)
@@ -67,7 +73,7 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
                 var brick = new Brick(r, c, cx, cy);
                 brick.Sprite.Color = BrickColors[r];
                 brick.Sprite.Shimmer.Start(Random.Shared.NextSingle() * brick.Sprite.Shimmer.Period);
-                _bricks.Add(brick);
+                _bricks.AddChild(brick);
             }
         }
     }
@@ -94,10 +100,10 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
 
     public override void Update(float deltaTime)
     {
+        // Entity.Update handles rigidbody step + sprite update via OnUpdate
         _paddle.Update(deltaTime);
-
-        foreach (var brick in _bricks)
-            brick.Sprite.Update(deltaTime);
+        _ball.Update(deltaTime);
+        _bricks.Update(deltaTime);
 
         // Power-up timers
         _strongBallTimer.Tick(deltaTime);
@@ -109,18 +115,13 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
             _paddle.X = Math.Clamp(_paddle.X, halfW, GameWidth - halfW);
         }
 
-        // Physics step
-        _ball.Rigidbody.Step(_ball, deltaTime);
-
-        // Boundary wall collisions (left, top, right bounce; bottom = life lost)
-        foreach (var wall in (ReadOnlySpan<Wall>)[_leftWall, _topWall, _rightWall])
-        {
-            if (CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, wall.X, wall.Y, wall.Collider, out var wallHit))
-                _ball.Rigidbody.Bounce(wallHit);
-        }
+        // Boundary wall collisions
+        _ball.BounceOff(_leftWall);
+        _ball.BounceOff(_topWall);
+        _ball.BounceOff(_rightWall);
 
         // Ball hit the bottom wall — lose a life
-        if (CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _bottomWall.X, _bottomWall.Y, _bottomWall.Collider, out _))
+        if (_ball.Overlaps(_bottomWall))
         {
             state.Lives--;
             if (state.Lives <= 0)
@@ -139,21 +140,18 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         // Falling power-ups
         UpdateFallingPowerUps(deltaTime);
 
-        if (!_bricks.Any(b => b.Active))
+        if (!_bricks.Children.Any(b => b.Active))
             coordinator.PushOverlay<VictoryScreen>();
     }
 
     private void ResolvePaddleCollision()
     {
-        if (_ball.Rigidbody.VelocityY > 0f &&
-            CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _paddle.X, _paddle.Y, _paddle.Collider, out var hit))
+        if (_ball.Rigidbody.VelocityY > 0f && _ball.TryGetHit(_paddle, out var hit))
         {
-            // Push the ball out of the paddle so it cannot oscillate inside it.
             _ball.X += hit.NormalX * hit.Penetration;
             _ball.Y += hit.NormalY * hit.Penetration;
 
-            // Clamp hitPos to [-1, 1] so corner overlaps don't produce extreme angles.
-            float hitPos = Math.Clamp((_ball.X - _paddle.X) / (_paddle.Width / 2f), -1f, 1f);
+            float hitPos = Math.Clamp((_ball.WorldX - _paddle.WorldX) / (_paddle.Width / 2f), -1f, 1f);
             float angle = hitPos * (65f * MathF.PI / 180f);
             _ball.Rigidbody.SetVelocity(
                 BallSpeed * MathF.Sin(angle),
@@ -165,11 +163,11 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
     {
         bool piercing = _strongBallTimer.Active;
 
-        foreach (var brick in _bricks)
+        // Use FindChildCollision for broad-phase + narrow-phase
+        while (true)
         {
-            if (!brick.Active ||
-                !CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, brick.X, brick.Y, brick.Collider, out var hit))
-                continue;
+            if (_bricks.FindChildCollision(_ball, out var hit) is not Brick brick)
+                break;
 
             brick.Active = false;
             state.Score += 10 * (BrickRows - brick.Row);
@@ -178,7 +176,7 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
             if (!piercing)
             {
                 _ball.Rigidbody.Bounce(hit);
-                return;
+                break;
             }
         }
     }
@@ -189,30 +187,28 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         var type = Random.Shared.NextDouble() < 0.5 ? PowerUpType.StrongBall : PowerUpType.BigPaddle;
         var pu = new FallingPowerUp { X = cx, Y = cy, Type = type };
         pu.Sprite.Color = type == PowerUpType.StrongBall ? StrongBallColor : BigPaddleColor;
-        _powerUps.Add(pu);
+        _powerUps.AddChild(pu);
     }
 
     private void UpdateFallingPowerUps(float deltaTime)
     {
+        _powerUps.Update(deltaTime);
         float halfPaddleW = _paddle.Width / 2f;
 
-        for (int i = _powerUps.Count - 1; i >= 0; i--)
+        foreach (var child in _powerUps.Children.ToArray())
         {
-            var pu = _powerUps[i];
+            if (child is not FallingPowerUp pu || !pu.Active) continue;
 
-            pu.Rigidbody.Step(pu, deltaTime);
-
-            // Paddle collision: power-up centre Y within paddle vertical range, X within paddle width
             if (pu.Y + PowerUpH / 2f >= PaddleY &&
                 pu.Y - PowerUpH / 2f <= PaddleY + PaddleHeight &&
                 pu.X >= _paddle.X - halfPaddleW && pu.X <= _paddle.X + halfPaddleW)
             {
                 ApplyPowerUp(pu.Type);
-                _powerUps.RemoveAt(i);
+                _powerUps.RemoveChild(pu);
             }
             else if (pu.Y > GameHeight + 30f)
             {
-                _powerUps.RemoveAt(i);
+                _powerUps.RemoveChild(pu);
             }
         }
     }
@@ -241,18 +237,14 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
 
     internal void DrawGameContent(SKCanvas canvas)
     {
-        // Bricks
-        foreach (var brick in _bricks)
-        {
-            if (!brick.Active) continue;
-            brick.Sprite.Alpha = 1f;
-            canvas.Save(); canvas.Translate(brick.X, brick.Y); brick.Sprite.Draw(canvas); canvas.Restore();
-        }
+        // Entity groups draw all children recursively
+        _bricks.Draw(canvas);
+        _powerUps.Draw(canvas);
 
-        // Falling power-ups
-        foreach (var pu in _powerUps)
+        // Draw power-up labels on top of power-up sprites
+        foreach (var child in _powerUps.Children)
         {
-            canvas.Save(); canvas.Translate(pu.X, pu.Y); pu.Sprite.Draw(canvas); canvas.Restore();
+            if (child is not FallingPowerUp pu || !pu.Active) continue;
             _powerUpLabel.Text = pu.Type == PowerUpType.StrongBall ? "S" : "B";
             canvas.Save(); canvas.Translate(pu.X, pu.Y + 4f); _powerUpLabel.Draw(canvas); canvas.Restore();
         }
@@ -260,12 +252,12 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         // Paddle
         _paddle.Sprite.Color = _bigPaddleTimer.Active || _paddle.IsWidthAnimating
             ? BigPaddleColor : PaddleColor;
-        canvas.Save(); canvas.Translate(_paddle.X, _paddle.Y); _paddle.Sprite.Draw(canvas); canvas.Restore();
+        _paddle.Draw(canvas);
 
         // Ball
         _ball.Sprite.Color = _strongBallTimer.Active ? StrongBallColor : SKColors.White;
         _ball.Sprite.GlowColor = _strongBallTimer.Active ? StrongBallColor : SKColors.White;
-        canvas.Save(); canvas.Translate(_ball.X, _ball.Y); _ball.Sprite.Draw(canvas); canvas.Restore();
+        _ball.Draw(canvas);
 
         // HUD
         _scoreText.Text = $"Score: {state.Score}";

--- a/src/Breakout/PlayScreen.cs
+++ b/src/Breakout/PlayScreen.cs
@@ -22,6 +22,9 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
     private CountdownTimer _strongBallTimer;
     private CountdownTimer _bigPaddleTimer;
 
+    // ── Keyboard tracking ──────────────────────────────────────────────────
+    private bool _leftHeld, _rightHeld;
+
     // ── Entity groups (parenting) ─────────────────────────────────────────
     private readonly Entity _bricks = new();
     private readonly Entity _powerUps = new();
@@ -96,10 +99,36 @@ internal sealed class PlayScreen(BreakoutGameState state, IScreenCoordinator coo
         _paddle.X = Math.Clamp(x, halfW, GameWidth - halfW);
     }
 
+    public override void OnKeyDown(string key)
+    {
+        switch (key)
+        {
+            case "ArrowLeft": _leftHeld = true; break;
+            case "ArrowRight": _rightHeld = true; break;
+        }
+    }
+
+    public override void OnKeyUp(string key)
+    {
+        switch (key)
+        {
+            case "ArrowLeft": _leftHeld = false; break;
+            case "ArrowRight": _rightHeld = false; break;
+        }
+    }
+
     // ── Update ────────────────────────────────────────────────────────────
 
     public override void Update(float deltaTime)
     {
+        // Keyboard-driven paddle movement
+        if (_leftHeld ^ _rightHeld)
+        {
+            float direction = _leftHeld ? -1f : 1f;
+            float halfW = _paddle.Width / 2f;
+            _paddle.X = Math.Clamp(_paddle.X + direction * PaddleSpeed * deltaTime, halfW, GameWidth - halfW);
+        }
+
         // Entity.Update handles rigidbody step + sprite update via OnUpdate
         _paddle.Update(deltaTime);
         _ball.Update(deltaTime);

--- a/src/Breakout/PowerUpSprite.cs
+++ b/src/Breakout/PowerUpSprite.cs
@@ -16,14 +16,14 @@ internal sealed class PowerUpSprite : Sprite
 
     public float CornerRadius { get; set; } = 5f;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
         canvas.DrawRoundRect(
-            new SKRoundRect(SKRect.Create(x - Width / 2f, y - Height / 2f, Width, Height), CornerRadius),
+            new SKRoundRect(SKRect.Create(0 - Width / 2f, 0 - Height / 2f, Width, Height), CornerRadius),
             _paint);
     }
 }

--- a/src/Breakout/StartScreen.cs
+++ b/src/Breakout/StartScreen.cs
@@ -9,7 +9,7 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
 {
     private readonly TextSprite _title = new() { Text = "BREAKOUT", Size = 72f, Color = SKColors.White, Align = TextAlign.Center };
     private readonly TextSprite _startPrompt = new() { Text = "Click or Tap to Start", Size = 28f, Color = AccentColor, Align = TextAlign.Center };
-    private readonly TextSprite _instructions = new() { Text = "Move mouse / finger to control the paddle", Size = 18f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _instructions = new() { Text = "Move mouse / finger / arrow keys to control the paddle", Size = 18f, Color = DimColor, Align = TextAlign.Center };
 
     private readonly List<Brick> _bricks = [];
 

--- a/src/Breakout/StartScreen.cs
+++ b/src/Breakout/StartScreen.cs
@@ -43,12 +43,12 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
         foreach (var brick in _bricks)
         {
             brick.Sprite.Alpha = 0.3f;
-            brick.Sprite.Draw(canvas, brick.X, brick.Y);
+            canvas.Save(); canvas.Translate(brick.X, brick.Y); brick.Sprite.Draw(canvas); canvas.Restore();
         }
 
-        _title.Draw(canvas, GameWidth / 2f, 290f);
-        _startPrompt.Draw(canvas, GameWidth / 2f, 360f);
-        _instructions.Draw(canvas, GameWidth / 2f, 415f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 290f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 360f); _startPrompt.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 415f); _instructions.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y)

--- a/src/Breakout/VictoryScreen.cs
+++ b/src/Breakout/VictoryScreen.cs
@@ -20,10 +20,10 @@ internal sealed class VictoryScreen(BreakoutGameState state, IScreenCoordinator 
     {
         canvas.DrawRect(0, 0, GameWidth, GameHeight, _overlayPaint);
 
-        _titleText.Draw(canvas, GameWidth / 2f, 270f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 270f); _titleText.Draw(canvas); canvas.Restore();
         _scoreText.Text = $"Final Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 335f);
-        _promptText.Draw(canvas, GameWidth / 2f, 395f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 335f); _scoreText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 395f); _promptText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y)

--- a/src/Breakout/Wall.cs
+++ b/src/Breakout/Wall.cs
@@ -3,13 +3,10 @@ using SkiaSharpGames.GameEngine;
 namespace SkiaSharpGames.Breakout;
 
 /// <summary>
-/// An invisible wall used for boundary collisions. The ball bounces off these
-/// using the same <see cref="CollisionResolver.TryGetHit"/> path as bricks and paddle.
+/// An invisible wall used for boundary collisions.
 /// </summary>
 internal sealed class Wall : Entity
 {
-    public readonly RectCollider Collider;
-
     public Wall(float x, float y, float width, float height)
     {
         X = x;

--- a/src/CastleAttack/ArcherSprite.cs
+++ b/src/CastleAttack/ArcherSprite.cs
@@ -10,14 +10,12 @@ internal sealed class ArcherSprite : Sprite
     private static readonly SKPaint BodyPaint = new() { Color = ColArcher, IsAntialias = true };
     private static readonly SKPaint BowPaint = new() { Color = ColArrow, StrokeWidth = 2f, IsAntialias = true };
 
-    /// <param name="x">Centre X of the archer.</param>
-    /// <param name="y">Base Y (feet) of the archer.</param>
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible) return;
 
-        canvas.DrawRect(SKRect.Create(x - ArcherW / 2f, y - ArcherH, ArcherW, ArcherH - 8f), BodyPaint);
-        canvas.DrawCircle(x, y - ArcherH - 5f, 6f, BodyPaint);
-        canvas.DrawLine(x + ArcherW / 2f, y - ArcherH + 4f, x + ArcherW / 2f + 8f, y - ArcherH / 2f, BowPaint);
+        canvas.DrawRect(SKRect.Create(0f - ArcherW / 2f, 0f - ArcherH, ArcherW, ArcherH - 8f), BodyPaint);
+        canvas.DrawCircle(0f, 0f - ArcherH - 5f, 6f, BodyPaint);
+        canvas.DrawLine(0f + ArcherW / 2f, 0f - ArcherH + 4f, 0f + ArcherW / 2f + 8f, 0f - ArcherH / 2f, BowPaint);
     }
 }

--- a/src/CastleAttack/Arrow.cs
+++ b/src/CastleAttack/Arrow.cs
@@ -4,10 +4,25 @@ namespace SkiaSharpGames.CastleAttack;
 
 internal sealed class Arrow : Entity
 {
-    public readonly Rigidbody2D Rigidbody = new();
-    public readonly CircleCollider Collider = new() { Radius = 2f };
     public bool IsEnemy;
     public int EnemyTargetWall;
 
-    public readonly ArrowSprite Sprite = new();
+    public Arrow()
+    {
+        Collider = new CircleCollider { Radius = 2f };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new ArrowSprite();
+    }
+
+    public new ArrowSprite Sprite { get => (ArrowSprite)base.Sprite!; init => base.Sprite = value; }
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
+
+    protected override void OnUpdate(float deltaTime)
+    {
+        // Sync sprite with current velocity for angle-based drawing
+        Sprite.IsEnemy = IsEnemy;
+        Sprite.VelocityX = Rigidbody.VelocityX;
+        Sprite.VelocityY = Rigidbody.VelocityY;
+    }
 }

--- a/src/CastleAttack/ArrowSprite.cs
+++ b/src/CastleAttack/ArrowSprite.cs
@@ -14,7 +14,7 @@ internal sealed class ArrowSprite : Sprite
     private static readonly SKPaint FriendlyPaint = new() { Color = ColArrow, StrokeWidth = 2f, IsAntialias = true };
     private static readonly SKPaint EnemyPaint = new() { Color = ColFire, StrokeWidth = 2.5f, IsAntialias = true };
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible) return;
 
@@ -23,6 +23,6 @@ internal sealed class ArrowSprite : Sprite
         float dx = MathF.Cos(angle) * len;
         float dy = MathF.Sin(angle) * len;
         var paint = IsEnemy ? EnemyPaint : FriendlyPaint;
-        canvas.DrawLine(x - dx / 2f, y - dy / 2f, x + dx / 2f, y + dy / 2f, paint);
+        canvas.DrawLine(0f - dx / 2f, 0f - dy / 2f, 0f + dx / 2f, 0f + dy / 2f, paint);
     }
 }

--- a/src/CastleAttack/Boulder.cs
+++ b/src/CastleAttack/Boulder.cs
@@ -4,9 +4,15 @@ namespace SkiaSharpGames.CastleAttack;
 
 internal sealed class Boulder : Entity
 {
-    public readonly Rigidbody2D Rigidbody = new();
-    public readonly CircleCollider Collider = new() { Radius = 7f };
     public int TargetWallIdx;
 
-    public readonly BoulderSprite Sprite = new();
+    public Boulder()
+    {
+        Collider = new CircleCollider { Radius = 7f };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new BoulderSprite();
+    }
+
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 }

--- a/src/CastleAttack/BoulderSprite.cs
+++ b/src/CastleAttack/BoulderSprite.cs
@@ -9,9 +9,9 @@ internal sealed class BoulderSprite : Sprite
 {
     private static readonly SKPaint Paint = new() { Color = ColBoulder, IsAntialias = true };
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible) return;
-        canvas.DrawCircle(x, y, 7f, Paint);
+        canvas.DrawCircle(0f, 0f, 7f, Paint);
     }
 }

--- a/src/CastleAttack/ButtonSprite.cs
+++ b/src/CastleAttack/ButtonSprite.cs
@@ -19,10 +19,9 @@ internal sealed class ButtonSprite : Sprite
     private readonly TextSprite _labelText = new() { Align = TextAlign.Center };
 
     /// <summary>
-    /// Draws the button. The <paramref name="x"/> and <paramref name="y"/> parameters are ignored;
-    /// the button position comes from <see cref="Rect"/>.
+    /// Draws the button. The button position comes from <see cref="Rect"/>.
     /// </summary>
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible) return;
 
@@ -45,6 +44,6 @@ internal sealed class ButtonSprite : Sprite
         _labelText.Size = fontSize;
         _labelText.Color = col;
         _labelText.Alpha = alpha;
-        _labelText.Draw(canvas, Rect.MidX, Rect.MidY + fontSize * 0.38f);
+        canvas.Save(); canvas.Translate(Rect.MidX, Rect.MidY + fontSize * 0.38f); _labelText.Draw(canvas); canvas.Restore();
     }
 }

--- a/src/CastleAttack/CastleAttackConstants.cs
+++ b/src/CastleAttack/CastleAttackConstants.cs
@@ -33,7 +33,7 @@ internal static class CastleAttackConstants
     public const float ArrowSpeed = 580f;
     public const float ArrowGravity = 480f;
 
-    public const float WorkerBuildRate = 1f / 110f;
+    public const float WorkerBuildRate = 1f / 300f;
 
     public const float LordMeleeRange = 30f;
     public const float LordAttackDamage = 2f;

--- a/src/CastleAttack/CastleAttackConstants.cs
+++ b/src/CastleAttack/CastleAttackConstants.cs
@@ -66,7 +66,7 @@ internal static class CastleAttackConstants
     public static readonly SKRect BtnW2A = SKRect.Create(338f, BtnY, 116f, BtnH);
     public static readonly SKRect BtnFire = SKRect.Create(470f, BtnY, 260f, BtnH);
     public static readonly SKRect BtnOil = SKRect.Create(750f, BtnY, 140f, BtnH);
-    public static readonly SKRect BtnCannon = SKRect.Create(898f, BtnY, 148f, BtnH);
+    public static readonly SKRect BtnMangonel = SKRect.Create(898f, BtnY, 148f, BtnH);
     public static readonly SKRect BtnLogs = SKRect.Create(1054f, BtnY, 140f, BtnH);
 
     // ── Colours ───────────────────────────────────────────────────────────
@@ -101,9 +101,9 @@ internal static class CastleAttackConstants
     public const float OilPuddleDuration = 3f;
     public const float OilDamage = 100f;
 
-    public const float MangonelDamage = 3f;
+    public const float MangonelDamage = 5f;
     public const int MangonelStoneCount = 6;
-    public const float MangonelLaunchSpeed = 350f;
+    public const float MangonelLaunchSpeed = 600f;
 
     public const float LogSpeed = 300f;
     public const float LogWidth = 30f;

--- a/src/CastleAttack/CastleAttackConstants.cs
+++ b/src/CastleAttack/CastleAttackConstants.cs
@@ -102,7 +102,7 @@ internal static class CastleAttackConstants
     public const float OilDamage = 100f;
 
     public const float MangonelDamage = 5f;
-    public const int MangonelStoneCount = 6;
+    public const int MangonelStoneCount = 12;
     public const float MangonelLaunchSpeed = 600f;
 
     public const float LogSpeed = 300f;

--- a/src/CastleAttack/CastleAttackConstants.cs
+++ b/src/CastleAttack/CastleAttackConstants.cs
@@ -93,6 +93,25 @@ internal static class CastleAttackConstants
     public static readonly SKColor ColGold = new(0xFF, 0xD7, 0x00);
     public static readonly SKColor ColRed = new(0xFF, 0x2D, 0x55);
 
+    // ── Special weapons ─────────────────────────────────────────────────
+    public const float OilDropRadius = 5f;
+    public const float OilDropSpeed = 300f;
+    public const float OilPuddleWidth = 60f;
+    public const float OilPuddleHeight = 6f;
+    public const float OilPuddleDuration = 3f;
+    public const float OilDamage = 100f;
+
+    public const float MangonelDamage = 3f;
+    public const int MangonelStoneCount = 6;
+    public const float MangonelLaunchSpeed = 350f;
+
+    public const float LogSpeed = 300f;
+    public const float LogWidth = 30f;
+    public const float LogHeight = 12f;
+    public const float LogDamageSmall = 100f;
+    public const float LogDamageLarge = 3f;
+    public static readonly SKColor ColLog = new(0x8B, 0x5E, 0x2E);
+
     public static SKColor EnemyCol(EnemyType t) => t switch
     {
         EnemyType.Spearman => new(0xE7, 0x4C, 0x3C),

--- a/src/CastleAttack/Enemy.cs
+++ b/src/CastleAttack/Enemy.cs
@@ -17,11 +17,23 @@ internal sealed class Enemy : Entity
     public float FireCooldown;
     public float FireInterval = 2.5f;
 
-    /// <summary>
-    /// Hitbox. Width and Height are also used for drawing — they define the visual size of the enemy.
-    /// </summary>
-    public RectCollider Collider = new();
-    public readonly Rigidbody2D Rigidbody = new();
+    public Enemy()
+    {
+        Collider = new RectCollider();
+        Rigidbody = new Rigidbody2D();
+        Sprite = new EnemySprite();
+    }
 
-    public readonly EnemySprite Sprite = new();
+    public new EnemySprite Sprite { get => (EnemySprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
+
+    protected override void OnUpdate(float deltaTime)
+    {
+        // Sync sprite with current entity state
+        Sprite.HP = HP;
+        Sprite.MaxHP = MaxHP;
+        Sprite.Type = Type;
+        Sprite.Collider = Collider;
+    }
 }

--- a/src/CastleAttack/EnemySprite.cs
+++ b/src/CastleAttack/EnemySprite.cs
@@ -29,22 +29,22 @@ internal sealed class EnemySprite : Sprite
 
     private readonly TextSprite _mooText = new() { Text = "MOO", Size = 10f, Color = new SKColor(0x55, 0x44, 0x22), Align = TextAlign.Center };
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible) return;
 
         SKColor col = CastleAttackConstants.EnemyCol(Type);
         switch (Type)
         {
-            case EnemyType.Catapult: DrawCatapult(canvas, x, y, col); break;
-            case EnemyType.Ram: DrawRam(canvas, x, y, col); break;
-            case EnemyType.Cow: DrawCow(canvas, x, y, col); break;
-            default: DrawHumanoid(canvas, x, y, col); break;
+            case EnemyType.Catapult: DrawCatapult(canvas, 0f, 0f, col); break;
+            case EnemyType.Ram: DrawRam(canvas, 0f, 0f, col); break;
+            case EnemyType.Cow: DrawCow(canvas, 0f, 0f, col); break;
+            default: DrawHumanoid(canvas, 0f, 0f, col); break;
         }
 
         if (MaxHP > 1f)
         {
-            float ex = x - Collider.Width / 2f;
+            float ex = 0f - Collider.Width / 2f;
             float ey = GroundY - Collider.Height;
             float barW = Collider.Width + 4f;
             float ratio = HP / MaxHP;
@@ -113,6 +113,6 @@ internal sealed class EnemySprite : Sprite
         canvas.DrawLine(ex + 4f, ey + Collider.Height - 4f, ex + 4f, GroundY, LegPaint);
         canvas.DrawLine(ex + Collider.Width - 4f, ey + Collider.Height - 4f, ex + Collider.Width - 4f, GroundY, LegPaint);
         canvas.DrawCircle(cx, ey + 8f, 3f, SpotPaint);
-        _mooText.Draw(canvas, cx, ey);
+        canvas.Save(); canvas.Translate(cx, ey); _mooText.Draw(canvas); canvas.Restore();
     }
 }

--- a/src/CastleAttack/EnemySprite.cs
+++ b/src/CastleAttack/EnemySprite.cs
@@ -36,83 +36,83 @@ internal sealed class EnemySprite : Sprite
         SKColor col = CastleAttackConstants.EnemyCol(Type);
         switch (Type)
         {
-            case EnemyType.Catapult: DrawCatapult(canvas, 0f, 0f, col); break;
-            case EnemyType.Ram: DrawRam(canvas, 0f, 0f, col); break;
-            case EnemyType.Cow: DrawCow(canvas, 0f, 0f, col); break;
-            default: DrawHumanoid(canvas, 0f, 0f, col); break;
+            case EnemyType.Catapult: DrawCatapult(canvas, col); break;
+            case EnemyType.Ram: DrawRam(canvas, col); break;
+            case EnemyType.Cow: DrawCow(canvas, col); break;
+            default: DrawHumanoid(canvas, col); break;
         }
 
         if (MaxHP > 1f)
         {
-            float ex = 0f - Collider.Width / 2f;
-            float ey = GroundY - Collider.Height;
             float barW = Collider.Width + 4f;
             float ratio = HP / MaxHP;
-            canvas.DrawRect(SKRect.Create(ex - 2f, ey - 8f, barW, 4f), HpBarBg);
+            float barX = -barW / 2f;
+            float barY = -Collider.Height / 2f - 10f;
+            canvas.DrawRect(SKRect.Create(barX, barY, barW, 4f), HpBarBg);
             HpBarFg.Color = new SKColor(0xFF, 0x44, 0x00);
-            canvas.DrawRect(SKRect.Create(ex - 2f, ey - 8f, barW * ratio, 4f), HpBarFg);
+            canvas.DrawRect(SKRect.Create(barX, barY, barW * ratio, 4f), HpBarFg);
         }
     }
 
-    private void DrawHumanoid(SKCanvas canvas, float cx, float cy, SKColor col)
+    private void DrawHumanoid(SKCanvas canvas, SKColor col)
     {
-        float ex = cx - Collider.Width / 2f;
-        float ey = GroundY - Collider.Height;
+        float hw = Collider.Width / 2f;
+        float hh = Collider.Height / 2f;
 
         BodyPaint.Color = col;
-        canvas.DrawRect(SKRect.Create(ex, ey, Collider.Width, Collider.Height - 8f), BodyPaint);
-        canvas.DrawCircle(cx, ey - 5f, 6f, BodyPaint);
+        canvas.DrawRect(SKRect.Create(-hw, -hh, Collider.Width, Collider.Height - 8f), BodyPaint);
+        canvas.DrawCircle(0f, -hh - 5f, 6f, BodyPaint);
 
         if (Type == EnemyType.Crossbowman)
         {
-            canvas.DrawLine(ex - 4f, ey + Collider.Height / 3f, ex - 12f, ey + Collider.Height / 3f, CrossbowPaint);
+            canvas.DrawLine(-hw - 4f, -hh + Collider.Height / 3f, -hw - 12f, -hh + Collider.Height / 3f, CrossbowPaint);
         }
         else if (Type is EnemyType.Spearman or EnemyType.Berserker)
         {
-            canvas.DrawLine(ex - 2f, ey, ex - 14f, ey - 10f, SpearPaint);
+            canvas.DrawLine(-hw - 2f, -hh, -hw - 14f, -hh - 10f, SpearPaint);
         }
         else
         {
-            canvas.DrawLine(ex - 2f, ey + 2f, ex - 14f, ey + 8f, SwordPaint);
+            canvas.DrawLine(-hw - 2f, -hh + 2f, -hw - 14f, -hh + 8f, SwordPaint);
         }
     }
 
-    private void DrawCatapult(SKCanvas canvas, float cx, float cy, SKColor col)
+    private void DrawCatapult(SKCanvas canvas, SKColor col)
     {
-        float ex = cx - Collider.Width / 2f;
-        float ey = GroundY - Collider.Height;
+        float hw = Collider.Width / 2f;
+        float hh = Collider.Height / 2f;
 
         BodyPaint.Color = col;
-        canvas.DrawRoundRect(SKRect.Create(ex, ey + 8f, Collider.Width, Collider.Height - 8f), 3f, 3f, BodyPaint);
-        canvas.DrawLine(cx, ey + 14f, cx - 14f, ey, ArmPaint);
-        canvas.DrawCircle(ex + 6f, GroundY - 5f, 5f, WheelPaint);
-        canvas.DrawCircle(ex + Collider.Width - 6f, GroundY - 5f, 5f, WheelPaint);
+        canvas.DrawRoundRect(SKRect.Create(-hw, -hh + 8f, Collider.Width, Collider.Height - 8f), 3f, 3f, BodyPaint);
+        canvas.DrawLine(0f, -hh + 14f, -14f, -hh, ArmPaint);
+        canvas.DrawCircle(-hw + 6f, hh - 5f, 5f, WheelPaint);
+        canvas.DrawCircle(hw - 6f, hh - 5f, 5f, WheelPaint);
     }
 
-    private void DrawRam(SKCanvas canvas, float cx, float cy, SKColor col)
+    private void DrawRam(SKCanvas canvas, SKColor col)
     {
-        float ex = cx - Collider.Width / 2f;
-        float ey = GroundY - Collider.Height;
+        float hw = Collider.Width / 2f;
+        float hh = Collider.Height / 2f;
 
         BodyPaint.Color = col;
-        canvas.DrawRoundRect(SKRect.Create(ex, ey, Collider.Width, Collider.Height - 6f), 4f, 4f, BodyPaint);
-        canvas.DrawRect(SKRect.Create(ex - 10f, ey + 6f, 14f, 8f), TipPaint);
-        canvas.DrawCircle(ex + 6f, GroundY - 4f, 5f, WheelPaint);
-        canvas.DrawCircle(ex + Collider.Width - 6f, GroundY - 4f, 5f, WheelPaint);
+        canvas.DrawRoundRect(SKRect.Create(-hw, -hh, Collider.Width, Collider.Height - 6f), 4f, 4f, BodyPaint);
+        canvas.DrawRect(SKRect.Create(-hw - 10f, -hh + 6f, 14f, 8f), TipPaint);
+        canvas.DrawCircle(-hw + 6f, hh - 4f, 5f, WheelPaint);
+        canvas.DrawCircle(hw - 6f, hh - 4f, 5f, WheelPaint);
     }
 
-    private void DrawCow(SKCanvas canvas, float cx, float cy, SKColor col)
+    private void DrawCow(SKCanvas canvas, SKColor col)
     {
-        float ex = cx - Collider.Width / 2f;
-        float ey = GroundY - Collider.Height;
+        float hw = Collider.Width / 2f;
+        float hh = Collider.Height / 2f;
 
         BodyPaint.Color = col;
-        canvas.DrawRoundRect(SKRect.Create(ex, ey + 4f, Collider.Width, Collider.Height - 8f), 5f, 5f, BodyPaint);
+        canvas.DrawRoundRect(SKRect.Create(-hw, -hh + 4f, Collider.Width, Collider.Height - 8f), 5f, 5f, BodyPaint);
         HeadPaint.Color = col;
-        canvas.DrawRoundRect(SKRect.Create(ex - 8f, ey + 6f, 14f, 10f), 4f, 4f, HeadPaint);
-        canvas.DrawLine(ex + 4f, ey + Collider.Height - 4f, ex + 4f, GroundY, LegPaint);
-        canvas.DrawLine(ex + Collider.Width - 4f, ey + Collider.Height - 4f, ex + Collider.Width - 4f, GroundY, LegPaint);
-        canvas.DrawCircle(cx, ey + 8f, 3f, SpotPaint);
-        canvas.Save(); canvas.Translate(cx, ey); _mooText.Draw(canvas); canvas.Restore();
+        canvas.DrawRoundRect(SKRect.Create(-hw - 8f, -hh + 6f, 14f, 10f), 4f, 4f, HeadPaint);
+        canvas.DrawLine(-hw + 4f, hh - 4f, -hw + 4f, hh, LegPaint);
+        canvas.DrawLine(hw - 4f, hh - 4f, hw - 4f, hh, LegPaint);
+        canvas.DrawCircle(0f, -hh + 8f, 3f, SpotPaint);
+        canvas.Save(); canvas.Translate(0f, -hh); _mooText.Draw(canvas); canvas.Restore();
     }
 }

--- a/src/CastleAttack/FloatText.cs
+++ b/src/CastleAttack/FloatText.cs
@@ -5,10 +5,25 @@ namespace SkiaSharpGames.CastleAttack;
 
 internal sealed class FloatText : Entity
 {
-    public readonly Rigidbody2D Rigidbody = new() { VelocityY = -28f };
     public float Life;
     public string Text = "";
     public SKColor Color = SKColors.White;
 
-    public readonly FloatTextSprite Sprite = new();
+    public FloatText()
+    {
+        Rigidbody = new Rigidbody2D { VelocityY = -28f };
+        Sprite = new FloatTextSprite();
+    }
+
+    public new FloatTextSprite Sprite { get => (FloatTextSprite)base.Sprite!; init => base.Sprite = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
+
+    protected override void OnUpdate(float deltaTime)
+    {
+        Life -= deltaTime;
+        Sprite.Text = Text;
+        Sprite.Color = Color;
+        Sprite.Life = Life;
+        if (Life <= 0f) Active = false;
+    }
 }

--- a/src/CastleAttack/FloatTextSprite.cs
+++ b/src/CastleAttack/FloatTextSprite.cs
@@ -13,10 +13,10 @@ internal sealed class FloatTextSprite : Sprite
     public float Life { get; set; }
     public float MaxLife { get; set; } = 1.4f;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || string.IsNullOrEmpty(Text)) return;
         _text.Alpha = Math.Clamp(Life / MaxLife, 0f, 1f);
-        _text.Draw(canvas, x, y);
+        _text.Draw(canvas);
     }
 }

--- a/src/CastleAttack/GameOverScreen.cs
+++ b/src/CastleAttack/GameOverScreen.cs
@@ -22,10 +22,10 @@ internal sealed class GameOverScreen(CastleAttackGameState state, IScreenCoordin
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), OverlayPaint);
 
         float cx = GameWidth / 2f;
-        _defeatText.Draw(canvas, cx, 250f);
+        canvas.Save(); canvas.Translate(cx, 250f); _defeatText.Draw(canvas); canvas.Restore();
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, cx, 315f);
-        _retryText.Draw(canvas, cx, 370f);
+        canvas.Save(); canvas.Translate(cx, 315f); _scoreText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 370f); _retryText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y)

--- a/src/CastleAttack/LordSprite.cs
+++ b/src/CastleAttack/LordSprite.cs
@@ -18,24 +18,24 @@ internal sealed class LordSprite : Sprite
 
     /// <param name="x">Centre X of the lord.</param>
     /// <param name="y">Base Y (feet) of the lord.</param>
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Active || !Visible) return;
 
         const float barW = 40f;
-        canvas.DrawRect(SKRect.Create(x - barW / 2f, y - LordH - 14f, barW, 6f), HpBarBg);
+        canvas.DrawRect(SKRect.Create(0f - barW / 2f, 0f - LordH - 14f, barW, 6f), HpBarBg);
         HpBarFg.Color = new SKColor(0xFF, 0x22, 0x22);
-        canvas.DrawRect(SKRect.Create(x - barW / 2f, y - LordH - 14f, barW * HPRatio, 6f), HpBarFg);
+        canvas.DrawRect(SKRect.Create(0f - barW / 2f, 0f - LordH - 14f, barW * HPRatio, 6f), HpBarFg);
 
-        canvas.DrawRect(SKRect.Create(x - LordW / 2f, y - LordH, LordW, LordH - 8f), BodyPaint);
-        canvas.DrawCircle(x, y - LordH - 5f, 7f, BodyPaint);
+        canvas.DrawRect(SKRect.Create(0f - LordW / 2f, 0f - LordH, LordW, LordH - 8f), BodyPaint);
+        canvas.DrawCircle(0f, 0f - LordH - 5f, 7f, BodyPaint);
 
         // Crown
-        canvas.DrawRect(SKRect.Create(x - 7f, y - LordH - 17f, 4f, 6f), CrownPaint);
-        canvas.DrawRect(SKRect.Create(x - 2f, y - LordH - 20f, 4f, 9f), CrownPaint);
-        canvas.DrawRect(SKRect.Create(x + 3f, y - LordH - 17f, 4f, 6f), CrownPaint);
+        canvas.DrawRect(SKRect.Create(0f - 7f, 0f - LordH - 17f, 4f, 6f), CrownPaint);
+        canvas.DrawRect(SKRect.Create(0f - 2f, 0f - LordH - 20f, 4f, 9f), CrownPaint);
+        canvas.DrawRect(SKRect.Create(0f + 3f, 0f - LordH - 17f, 4f, 6f), CrownPaint);
 
         // Sword
-        canvas.DrawLine(x + LordW / 2f, y - LordH, x + LordW / 2f + 18f, y - LordH / 2f, SwordPaint);
+        canvas.DrawLine(0f + LordW / 2f, 0f - LordH, 0f + LordW / 2f + 18f, 0f - LordH / 2f, SwordPaint);
     }
 }

--- a/src/CastleAttack/OilDrop.cs
+++ b/src/CastleAttack/OilDrop.cs
@@ -1,0 +1,20 @@
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.CastleAttack.CastleAttackConstants;
+
+namespace SkiaSharpGames.CastleAttack;
+
+/// <summary>A boiling oil drop that falls from a wall and creates a puddle on impact.</summary>
+internal sealed class OilDrop : Entity
+{
+    public OilDrop(float x, float wallTopY)
+    {
+        X = x;
+        Y = wallTopY;
+        Collider = new CircleCollider { Radius = OilDropRadius };
+        Rigidbody = new Rigidbody2D { VelocityY = OilDropSpeed };
+        Sprite = new OilDropSprite();
+    }
+
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
+}

--- a/src/CastleAttack/OilDropSprite.cs
+++ b/src/CastleAttack/OilDropSprite.cs
@@ -1,0 +1,19 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.CastleAttack.CastleAttackConstants;
+
+namespace SkiaSharpGames.CastleAttack;
+
+/// <summary>Draws a falling oil drop as a dark brown circle with a faint glow.</summary>
+internal sealed class OilDropSprite : Sprite
+{
+    private static readonly SKPaint CorePaint = new() { Color = ColOil, IsAntialias = true };
+    private static readonly SKPaint GlowPaint = new() { Color = new SKColor(0xFF, 0x6B, 0x00, 60), IsAntialias = true };
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible) return;
+        canvas.DrawCircle(0f, 0f, OilDropRadius + 3f, GlowPaint);
+        canvas.DrawCircle(0f, 0f, OilDropRadius, CorePaint);
+    }
+}

--- a/src/CastleAttack/OilPuddle.cs
+++ b/src/CastleAttack/OilPuddle.cs
@@ -1,0 +1,28 @@
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.CastleAttack.CastleAttackConstants;
+
+namespace SkiaSharpGames.CastleAttack;
+
+/// <summary>A burning oil puddle that persists on the ground and damages enemies walking through it.</summary>
+internal sealed class OilPuddle : Entity
+{
+    public float Life = OilPuddleDuration;
+
+    public OilPuddle(float x)
+    {
+        X = x;
+        Y = GroundY - OilPuddleHeight / 2f;
+        Collider = new RectCollider { Width = OilPuddleWidth, Height = OilPuddleHeight };
+        Sprite = new OilPuddleSprite();
+    }
+
+    public new OilPuddleSprite Sprite { get => (OilPuddleSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+
+    protected override void OnUpdate(float deltaTime)
+    {
+        Life -= deltaTime;
+        Sprite.Life = Life;
+        if (Life <= 0f) Active = false;
+    }
+}

--- a/src/CastleAttack/OilPuddleSprite.cs
+++ b/src/CastleAttack/OilPuddleSprite.cs
@@ -1,0 +1,31 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.CastleAttack.CastleAttackConstants;
+
+namespace SkiaSharpGames.CastleAttack;
+
+/// <summary>Draws a burning oil puddle on the ground — a flat orange rectangle that flickers.</summary>
+internal sealed class OilPuddleSprite : Sprite
+{
+    public float Life;
+
+    private static readonly SKColor CoreColor = new(0xFF, 0x6B, 0x00);
+    private static readonly SKColor GlowColor = new(0xFF, 0x44, 0x00, 80);
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible) return;
+
+        byte alpha = (byte)(255 * Math.Clamp(Life / OilPuddleDuration, 0f, 1f));
+        using var corePaint = new SKPaint { Color = CoreColor.WithAlpha(alpha), IsAntialias = true };
+        using var glowPaint = new SKPaint { Color = GlowColor.WithAlpha((byte)(alpha / 3)), IsAntialias = true };
+
+        float hw = OilPuddleWidth / 2f;
+        float hh = OilPuddleHeight / 2f;
+
+        // Glow underneath
+        canvas.DrawRoundRect(-hw - 4f, -hh - 2f, OilPuddleWidth + 8f, OilPuddleHeight + 4f, 4f, 2f, glowPaint);
+        // Core puddle
+        canvas.DrawRoundRect(-hw, -hh, OilPuddleWidth, OilPuddleHeight, 3f, 2f, corePaint);
+    }
+}

--- a/src/CastleAttack/PlayScreen.cs
+++ b/src/CastleAttack/PlayScreen.cs
@@ -13,6 +13,9 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     private readonly List<Arrow> _arrows = [];
     private readonly List<Boulder> _boulders = [];
     private readonly List<FloatText> _texts = [];
+    private readonly List<OilDrop> _oilDrops = [];
+    private readonly List<OilPuddle> _oilPuddles = [];
+    private readonly List<RollingLog> _logs = [];
 
     private int _archerCount = 3;
     private int _workerCount = 3;
@@ -139,6 +142,9 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         _arrows.Clear();
         _boulders.Clear();
         _texts.Clear();
+        _oilDrops.Clear();
+        _oilPuddles.Clear();
+        _logs.Clear();
         InitWalls();
     }
 
@@ -240,12 +246,11 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     {
         if (!_oilAvail) return;
         _oilAvail = false;
-        float maxRange = OuterWallX + BlockW + 80f;
-        foreach (var e in _enemies)
+        foreach (var wall in _walls)
         {
-            if (!e.Active || e.X > maxRange) continue;
-            if (e.Type is EnemyType.Catapult or EnemyType.Ram) continue;
-            KillEnemy(e, 0f, 0f);
+            if (!wall.HasArcher || wall.IsDestroyed) continue;
+            _oilDrops.Add(new OilDrop(wall.CenterX - 10f, wall.TopY));
+            _oilDrops.Add(new OilDrop(wall.CenterX + 10f, wall.TopY));
         }
         SpawnText("BOILING OIL!", GameWidth / 2f, 120f, ColOil);
     }
@@ -254,11 +259,19 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     {
         if (!_mangonelAvail) return;
         _mangonelAvail = false;
-        float minX = OuterWallX + BlockW + 200f;
-        foreach (var e in _enemies)
+        float launchX = KeepLeft + 40f;
+        float launchY = GroundY - 60f;
+        for (int i = 0; i < MangonelStoneCount; i++)
         {
-            if (!e.Active || e.X < minX) continue;
-            KillEnemy(e, 0f, 0f);
+            float angleDeg = 45f + Random.Shared.NextSingle() * 30f; // 45-75 degrees
+            float speed = MangonelLaunchSpeed * (0.8f + Random.Shared.NextSingle() * 0.4f);
+            float rad = angleDeg * MathF.PI / 180f;
+            float vx = speed * MathF.Cos(rad);
+            float vy = -speed * MathF.Sin(rad);
+            var stone = new Boulder { X = launchX + Random.Shared.NextSingle() * 20f, Y = launchY, TargetWallIdx = -1 };
+            stone.Rigidbody.VelocityX = vx;
+            stone.Rigidbody.VelocityY = vy;
+            _boulders.Add(stone);
         }
         SpawnText("MANGONEL FIRES!", GameWidth / 2f, 120f, ColBoulder);
     }
@@ -267,11 +280,18 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     {
         if (!_logsAvail) return;
         _logsAvail = false;
-        foreach (var e in _enemies)
+        // Spawn from outermost standing wall
+        float spawnX = OuterWallX + BlockW;
+        for (int i = _walls.Count - 1; i >= 0; i--)
         {
-            if (!e.Active) continue;
-            KillEnemy(e, 0f, 0f);
+            if (!_walls[i].IsDestroyed)
+            {
+                spawnX = _walls[i].LeftX + BlockW;
+                break;
+            }
         }
+        for (int i = 0; i < 3; i++)
+            _logs.Add(new RollingLog(spawnX + i * 20f));
         SpawnText("FLAMING LOGS!", GameWidth / 2f, 120f, ColFire);
     }
 
@@ -361,6 +381,8 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         if (_lordActive) UpdateLord(deltaTime);
         UpdateArrows(deltaTime);
         UpdateBoulders(deltaTime);
+        UpdateOil(deltaTime);
+        UpdateLogs(deltaTime);
 
         for (int i = _texts.Count - 1; i >= 0; i--)
         {
@@ -734,6 +756,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
 
             if (b.TargetWallIdx >= 0 && b.TargetWallIdx < _walls.Count)
             {
+                // Enemy catapult boulder — hits walls
                 var wall = _walls[b.TargetWallIdx];
                 if (!wall.IsDestroyed && b.X >= wall.LeftX - 10f && b.X <= wall.LeftX + BlockW + 10f)
                 {
@@ -743,6 +766,100 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
                     b.Active = false;
                     _boulders.RemoveAt(i);
                 }
+            }
+            else
+            {
+                // Player mangonel stone — hits enemies
+                bool hit = false;
+                foreach (var e in _enemies)
+                {
+                    if (!e.Active) continue;
+                    if (!b.TryGetHit(e, out _)) continue;
+
+                    e.HP -= MangonelDamage;
+                    if (e.HP <= 0f) KillEnemy(e, b.X, b.Y);
+                    else SpawnText($"-{MangonelDamage:0}", e.X, GroundY - e.Collider.Height - 5f, ColBoulder);
+                    hit = true;
+                    break;
+                }
+                if (hit || b.Y >= GroundY - 4f)
+                {
+                    b.Active = false;
+                    _boulders.RemoveAt(i);
+                }
+            }
+        }
+    }
+
+    // ── Oil update ────────────────────────────────────────────────────────
+
+    private void UpdateOil(float dt)
+    {
+        // Update oil drops — fall and create puddles on ground impact
+        for (int i = _oilDrops.Count - 1; i >= 0; i--)
+        {
+            var drop = _oilDrops[i];
+            if (!drop.Active) { _oilDrops.RemoveAt(i); continue; }
+
+            drop.Update(dt);
+
+            if (drop.Y >= GroundY - OilPuddleHeight)
+            {
+                _oilPuddles.Add(new OilPuddle(drop.X));
+                drop.Active = false;
+                _oilDrops.RemoveAt(i);
+            }
+        }
+
+        // Update puddles — damage enemies that walk through
+        for (int i = _oilPuddles.Count - 1; i >= 0; i--)
+        {
+            var puddle = _oilPuddles[i];
+            if (!puddle.Active) { _oilPuddles.RemoveAt(i); continue; }
+
+            puddle.Update(dt);
+
+            foreach (var e in _enemies)
+            {
+                if (!e.Active) continue;
+                if (e.Type is EnemyType.Catapult or EnemyType.Ram) continue;
+                if (!puddle.Overlaps(e)) continue;
+
+                e.HP -= OilDamage;
+                if (e.HP <= 0f) KillEnemy(e, e.X, GroundY - e.Collider.Height);
+            }
+        }
+    }
+
+    // ── Logs update ───────────────────────────────────────────────────────
+
+    private void UpdateLogs(float dt)
+    {
+        for (int i = _logs.Count - 1; i >= 0; i--)
+        {
+            var log = _logs[i];
+            if (!log.Active) { _logs.RemoveAt(i); continue; }
+
+            log.Update(dt);
+
+            // Off-screen removal
+            if (log.X > GameWidth + LogWidth)
+            {
+                log.Active = false;
+                _logs.RemoveAt(i);
+                continue;
+            }
+
+            // Check enemy collisions
+            foreach (var e in _enemies)
+            {
+                if (!e.Active) continue;
+                if (!log.Overlaps(e)) continue;
+
+                float dmg = e.Type is EnemyType.Ram or EnemyType.Catapult ? LogDamageLarge : LogDamageSmall;
+                e.HP -= dmg;
+                if (e.HP <= 0f) KillEnemy(e, e.X, GroundY - e.Collider.Height);
+                else SpawnText($"-{dmg:0}", e.X, GroundY - e.Collider.Height - 5f, ColFire);
             }
         }
     }
@@ -792,8 +909,11 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         DrawWalls(canvas);
         DrawWorkers(canvas);
         DrawLord(canvas);
+        DrawOilPuddles(canvas);
         DrawEnemies(canvas, _enemies);
+        DrawOilDrops(canvas);
         DrawBoulders(canvas, _boulders);
+        DrawLogs(canvas);
         DrawArrows(canvas, _arrows);
         DrawAimIndicator(canvas);
         DrawFloatTexts(canvas);
@@ -924,6 +1044,35 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         {
             if (!b.Active) continue;
             b.Draw(canvas);
+        }
+    }
+
+    // ── Oil / Logs draw ──────────────────────────────────────────────────
+
+    private void DrawOilDrops(SKCanvas canvas)
+    {
+        foreach (var d in _oilDrops)
+        {
+            if (!d.Active) continue;
+            d.Draw(canvas);
+        }
+    }
+
+    private void DrawOilPuddles(SKCanvas canvas)
+    {
+        foreach (var p in _oilPuddles)
+        {
+            if (!p.Active) continue;
+            p.Draw(canvas);
+        }
+    }
+
+    private void DrawLogs(SKCanvas canvas)
+    {
+        foreach (var log in _logs)
+        {
+            if (!log.Active) continue;
+            log.Draw(canvas);
         }
     }
 

--- a/src/CastleAttack/PlayScreen.cs
+++ b/src/CastleAttack/PlayScreen.cs
@@ -166,7 +166,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         if (BtnW2A.Contains(x, y)) { ConvertWorkerToArcher(); return; }
         if (BtnFire.Contains(x, y)) { FireVolley(); return; }
         if (BtnOil.Contains(x, y)) { UseOil(); return; }
-        if (BtnCannon.Contains(x, y)) { UseMangonel(); return; }
+        if (BtnMangonel.Contains(x, y)) { UseMangonel(); return; }
         if (BtnLogs.Contains(x, y)) { UseLogs(); return; }
 
         if (y < BtnY && x > KeepRight + 20f)
@@ -259,12 +259,13 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     {
         if (!_mangonelAvail) return;
         _mangonelAvail = false;
-        float launchX = KeepLeft + 40f;
-        float launchY = GroundY - 60f;
+        // Launch from behind the outer wall — a mangonel on the battlements
+        float launchX = OuterWallX;
+        float launchY = GroundY - 80f;
         for (int i = 0; i < MangonelStoneCount; i++)
         {
-            float angleDeg = 45f + Random.Shared.NextSingle() * 30f; // 45-75 degrees
-            float speed = MangonelLaunchSpeed * (0.8f + Random.Shared.NextSingle() * 0.4f);
+            float angleDeg = 30f + Random.Shared.NextSingle() * 25f; // 30-55 degrees
+            float speed = MangonelLaunchSpeed * (0.85f + Random.Shared.NextSingle() * 0.3f);
             float rad = angleDeg * MathF.PI / 180f;
             float vx = speed * MathF.Cos(rad);
             float vy = -speed * MathF.Sin(rad);
@@ -1206,7 +1207,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         DrawButton(canvas, BtnW2A, "Up W>A", canW2A, ColArcher, false);
         DrawButton(canvas, BtnFire, "FIRE", ready, SKColors.White, false, large: true);
         DrawButton(canvas, BtnOil, "Oil (Z)", _oilAvail, ColOil, false);
-        DrawButton(canvas, BtnCannon, "Cannon (X)", _mangonelAvail, ColBoulder, false);
+        DrawButton(canvas, BtnMangonel, "Mangonel (X)", _mangonelAvail, ColBoulder, false);
         DrawButton(canvas, BtnLogs, "Logs (C)", _logsAvail, ColFire, false);
     }
 

--- a/src/CastleAttack/PlayScreen.cs
+++ b/src/CastleAttack/PlayScreen.cs
@@ -365,9 +365,8 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
 
         for (int i = _texts.Count - 1; i >= 0; i--)
         {
-            _texts[i].Life -= deltaTime;
-            _texts[i].Rigidbody.Step(_texts[i], deltaTime);
-            if (_texts[i].Life <= 0f) _texts.RemoveAt(i);
+            _texts[i].Update(deltaTime);
+            if (!_texts[i].Active) _texts.RemoveAt(i);
         }
     }
 
@@ -420,7 +419,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             _                    => new Enemy { Type = type, X = SpawnX, HP = 1f,  MaxHP = 1f,  Speed = 50f,  Collider = new() { Width = 12f, Height = 24f } }
         };
         e.Y = GroundY - e.Collider.Height / 2f;
-        // Sync sprite
+        // Initial sprite sync (OnUpdate handles subsequent syncs)
         e.Sprite.Type = e.Type;
         e.Sprite.Collider = e.Collider;
         e.Sprite.HP = e.HP;
@@ -447,7 +446,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         {
             case EnemyType.Cow:
                 e.Rigidbody.VelocityX = -e.Speed;
-                e.Rigidbody.Step(e, dt);
+                e.Update(dt);
                 if (e.X < -e.Collider.Width) e.Active = false;
                 return;
             case EnemyType.Ram: UpdateRam(e, dt, tgtWall); return;
@@ -473,7 +472,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             {
                 e.State = EnemyState.Walking;
                 e.Rigidbody.VelocityX = -e.Speed;
-                e.Rigidbody.Step(e, dt);
+                e.Update(dt);
             }
             else
             {
@@ -496,7 +495,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         {
             e.State = EnemyState.Walking;
             e.Rigidbody.VelocityX = -e.Speed;
-            e.Rigidbody.Step(e, dt);
+            e.Update(dt);
         }
         else
         {
@@ -523,7 +522,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             if (e.X - e.Collider.Width / 2f > KeepRight + 5f)
             {
                 e.Rigidbody.VelocityX = -e.Speed;
-                e.Rigidbody.Step(e, dt);
+                e.Update(dt);
             }
             else
             {
@@ -538,7 +537,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         {
             e.State = EnemyState.Walking;
             e.Rigidbody.VelocityX = -e.Speed;
-            e.Rigidbody.Step(e, dt);
+            e.Update(dt);
         }
         else
         {
@@ -547,13 +546,13 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             UpdateArcherCount();
             SpawnText("WALL BREACHED!", wall.CenterX, wall.TopY - 50f, ColRed);
             e.Rigidbody.VelocityX = -e.Speed * 0.5f;
-            e.Rigidbody.Step(e, dt);
+            e.Update(dt);
         }
     }
 
     private void UpdateCatapult(Enemy e, float dt, int tgtWall)
     {
-        if (tgtWall < 0) { e.Rigidbody.VelocityX = -e.Speed; e.Rigidbody.Step(e, dt); return; }
+        if (tgtWall < 0) { e.Rigidbody.VelocityX = -e.Speed; e.Update(dt); return; }
 
         var wall = _walls[tgtWall];
         float stopX = wall.LeftX + BlockW + e.AttackRange + e.Collider.Width / 2f;
@@ -562,7 +561,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         {
             e.State = EnemyState.Walking;
             e.Rigidbody.VelocityX = -e.Speed;
-            e.Rigidbody.Step(e, dt);
+            e.Update(dt);
         }
         else
         {
@@ -591,7 +590,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         {
             e.State = EnemyState.Walking;
             e.Rigidbody.VelocityX = -e.Speed;
-            e.Rigidbody.Step(e, dt);
+            e.Update(dt);
         }
         else
         {
@@ -662,7 +661,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             if (!a.Active) { _arrows.RemoveAt(i); continue; }
 
             a.Rigidbody.VelocityY += ArrowGravity * dt;
-            a.Rigidbody.Step(a, dt);
+            a.Update(dt);
 
             if (a.X > GameWidth + 20f || a.X < -20f || a.Y > GroundY + 20f)
             {
@@ -682,7 +681,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         foreach (var e in _enemies)
         {
             if (!e.Active) continue;
-            if (!CollisionResolver.TryGetHit(a.X, a.Y, a.Collider, e.X, e.Y, e.Collider, out _)) continue;
+            if (!a.TryGetHit(e, out _)) continue;
 
             float pts = PointsForEnemy(e.Type);
             e.HP -= 1f;
@@ -729,7 +728,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             if (!b.Active) { _boulders.RemoveAt(i); continue; }
 
             b.Rigidbody.VelocityY += ArrowGravity * dt;
-            b.Rigidbody.Step(b, dt);
+            b.Update(dt);
 
             if (b.X < -40f || b.X > GameWidth + 40f || b.Y > GroundY + 20f)
             { b.Active = false; _boulders.RemoveAt(i); continue; }
@@ -905,8 +904,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         foreach (var e in enemies)
         {
             if (!e.Active) continue;
-            e.Sprite.HP = e.HP;
-            canvas.Save(); canvas.Translate(e.X, e.Y); e.Sprite.Draw(canvas); canvas.Restore();
+            e.Draw(canvas);
         }
     }
 
@@ -917,10 +915,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         foreach (var a in arrows)
         {
             if (!a.Active) continue;
-            a.Sprite.IsEnemy = a.IsEnemy;
-            a.Sprite.VelocityX = a.Rigidbody.VelocityX;
-            a.Sprite.VelocityY = a.Rigidbody.VelocityY;
-            canvas.Save(); canvas.Translate(a.X, a.Y); a.Sprite.Draw(canvas); canvas.Restore();
+            a.Draw(canvas);
         }
     }
 
@@ -929,7 +924,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         foreach (var b in boulders)
         {
             if (!b.Active) continue;
-            canvas.Save(); canvas.Translate(b.X, b.Y); b.Sprite.Draw(canvas); canvas.Restore();
+            b.Draw(canvas);
         }
     }
 
@@ -1068,10 +1063,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     {
         foreach (var t in _texts)
         {
-            t.Sprite.Text = t.Text;
-            t.Sprite.Color = t.Color;
-            t.Sprite.Life = t.Life;
-            canvas.Save(); canvas.Translate(t.X, t.Y); t.Sprite.Draw(canvas); canvas.Restore();
+            t.Draw(canvas);
         }
     }
 }

--- a/src/CastleAttack/PlayScreen.cs
+++ b/src/CastleAttack/PlayScreen.cs
@@ -81,10 +81,9 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
 
     private static readonly SKPaint AimDotPaint = new()
     {
-        Color = new SKColor(0xFF, 0xFF, 0xFF, 100),
-        StrokeWidth = 1.5f,
+        Color = new SKColor(0xFF, 0xFF, 0xFF, 60),
         IsAntialias = true,
-        PathEffect = SKPathEffect.CreateDash([4f, 6f], 0f)
+        Style = SKPaintStyle.Fill,
     };
     private static readonly SKPaint AimLandPaint = new() { Color = new SKColor(0xFF, 0xFF, 0x00, 180), IsAntialias = true };
 
@@ -934,33 +933,50 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     {
         if (_archerCount == 0) return;
 
+        float rad = _aimAngle * MathF.PI / 180f;
+        float vx = ArrowSpeed * MathF.Cos(rad);
+        float vy = -ArrowSpeed * MathF.Sin(rad);
+
+        // Draw arc from each archer wall
+        foreach (var wall in _walls)
+        {
+            if (wall.IsDestroyed || !wall.HasArcher) continue;
+
+            float ax = wall.ArcherCenterX;
+            float ay = wall.ArcherBaseY - ArcherH / 2f;
+
+            // Build a filled ribbon: trace the arc forward, then back slightly offset
+            using var path = new SKPath();
+            const float thickness = 3f;
+            bool first = true;
+            var topPoints = new List<SKPoint>();
+            for (float t = 0; t < 3f; t += 0.04f)
+            {
+                float nx = ax + vx * t;
+                float ny = ay + vy * t + 0.5f * ArrowGravity * t * t;
+                if (nx > GameWidth || ny > GroundY) break;
+                topPoints.Add(new SKPoint(nx, ny));
+                if (first) { path.MoveTo(nx, ny - thickness); first = false; }
+                else path.LineTo(nx, ny - thickness);
+            }
+            // Trace back along the bottom edge
+            for (int i = topPoints.Count - 1; i >= 0; i--)
+                path.LineTo(topPoints[i].X, topPoints[i].Y + thickness);
+            path.Close();
+            canvas.DrawPath(path, AimDotPaint);
+        }
+
+        // Landing marker from reference wall
         Wall? refWall = null;
         for (int i = _walls.Count - 1; i >= 0; i--)
             if (!_walls[i].IsDestroyed && _walls[i].HasArcher) { refWall = _walls[i]; break; }
         if (refWall == null) return;
 
-        float ax = refWall.ArcherCenterX;
-        float ay = refWall.ArcherBaseY - ArcherH / 2f;
-        float rad = _aimAngle * MathF.PI / 180f;
-        float vx = ArrowSpeed * MathF.Cos(rad);
-        float vy = -ArrowSpeed * MathF.Sin(rad);
-
-        using var path = new SKPath();
-        bool first = true;
-        for (float t = 0; t < 3f; t += 0.05f)
-        {
-            float nx = ax + vx * t;
-            float ny = ay + vy * t + 0.5f * ArrowGravity * t * t;
-            if (nx > GameWidth || ny > GroundY) break;
-            if (first) { path.MoveTo(nx, ny); first = false; }
-            else path.LineTo(nx, ny);
-        }
-        canvas.DrawPath(path, AimDotPaint);
-
-        float landT = FindLandingTime(ay, vy);
+        float refAy = refWall.ArcherBaseY - ArcherH / 2f;
+        float landT = FindLandingTime(refAy, vy);
         if (landT > 0f)
         {
-            float landX = ax + vx * landT;
+            float landX = refWall.ArcherCenterX + vx * landT;
             if (landX >= 0 && landX <= GameWidth)
                 canvas.DrawCircle(landX, GroundY - 3f, 5f, AimLandPaint);
         }

--- a/src/CastleAttack/PlayScreen.cs
+++ b/src/CastleAttack/PlayScreen.cs
@@ -58,7 +58,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     private readonly TextSprite _workerText = new() { Size = 16f, Color = ColWorker };
     private readonly TextSprite _keepLabel = new() { Text = "Keep", Size = 11f, Color = ColDim };
     private readonly TextSprite _aimText = new() { Size = 15f, Color = ColDim, Align = TextAlign.Center };
-    private readonly TextSprite _cooldownDot = new() { Text = "●", Size = 12f, Align = TextAlign.Center };
+    private readonly TextSprite _cooldownDot = new() { Text = "*", Size = 12f, Align = TextAlign.Center };
     private readonly TextSprite _lordHpText = new() { Size = 16f };
     private readonly TextSprite _accuracyText = new() { Size = 15f, Color = ColGold, Align = TextAlign.Center };
     private readonly TextSprite _keepProgressText = new() { Size = 13f, Align = TextAlign.Center };
@@ -212,7 +212,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
                 _walls[i].HasArcher = false;
                 _archerCount--;
                 _workerCount++;
-                SpawnText("Archer → Worker", _walls[i].CenterX, _walls[i].TopY - 40f, ColWorker);
+                SpawnText("Archer > Worker", _walls[i].CenterX, _walls[i].TopY - 40f, ColWorker);
                 return;
             }
         }
@@ -228,7 +228,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
                 _walls[i].HasArcher = true;
                 _archerCount++;
                 _workerCount--;
-                SpawnText("Worker → Archer", _walls[i].CenterX, _walls[i].TopY - 40f, ColArcher);
+                SpawnText("Worker > Archer", _walls[i].CenterX, _walls[i].TopY - 40f, ColArcher);
                 return;
             }
         }
@@ -1016,7 +1016,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         canvas.DrawRect(SKRect.Create(barX, barY, barW * _keepProgress, barH), HudBarFg);
         canvas.Save(); canvas.Translate(barX, barY - 3f); _keepLabel.Draw(canvas); canvas.Restore();
 
-        _aimText.Text = $"Aim: {_aimAngle:F0}°";
+        _aimText.Text = $"Aim: {_aimAngle:F0} deg";
         canvas.Save(); canvas.Translate(GameWidth / 2f, 20f); _aimText.Draw(canvas); canvas.Restore();
 
         if (_arrowCooldown.Active)
@@ -1036,7 +1036,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
 
         if (_archerCount == 1 && _accuracyMult > 1)
         {
-            _accuracyText.Text = $"Accuracy ×{_accuracyMult}";
+            _accuracyText.Text = $"Accuracy x{_accuracyMult}";
             canvas.Save(); canvas.Translate(GameWidth / 2f, 60f); _accuracyText.Draw(canvas); canvas.Restore();
         }
 
@@ -1051,10 +1051,10 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         bool canW2A = _workerCount > 1 && _archerCount < _walls.Count;
         bool ready = !_arrowCooldown.Active && _archerCount > 0;
 
-        DrawButton(canvas, BtnAimLeft, "← Aim", true, ColDim, _touchAimLeft);
-        DrawButton(canvas, BtnAimRight, "Aim →", true, ColDim, _touchAimRight);
-        DrawButton(canvas, BtnA2W, "↓ A→W", canA2W, ColWorker, false);
-        DrawButton(canvas, BtnW2A, "↑ W→A", canW2A, ColArcher, false);
+        DrawButton(canvas, BtnAimLeft, "< Aim", true, ColDim, _touchAimLeft);
+        DrawButton(canvas, BtnAimRight, "Aim >", true, ColDim, _touchAimRight);
+        DrawButton(canvas, BtnA2W, "Dn A>W", canA2W, ColWorker, false);
+        DrawButton(canvas, BtnW2A, "Up W>A", canW2A, ColArcher, false);
         DrawButton(canvas, BtnFire, "FIRE", ready, SKColors.White, false, large: true);
         DrawButton(canvas, BtnOil, "Oil (Z)", _oilAvail, ColOil, false);
         DrawButton(canvas, BtnCannon, "Cannon (X)", _mangonelAvail, ColBoulder, false);

--- a/src/CastleAttack/PlayScreen.cs
+++ b/src/CastleAttack/PlayScreen.cs
@@ -682,7 +682,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         foreach (var e in _enemies)
         {
             if (!e.Active) continue;
-            if (!CollisionResolver.Overlaps(a, a.Collider, e, e.Collider)) continue;
+            if (!CollisionResolver.TryGetHit(a.X, a.Y, a.Collider, e.X, e.Y, e.Collider, out _)) continue;
 
             float pts = PointsForEnemy(e.Type);
             e.HP -= 1f;
@@ -846,7 +846,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             _keepProgressText.Text = "COMPLETE!";
             _keepProgressText.Color = ColGold;
         }
-        _keepProgressText.Draw(canvas, (KeepLeft + KeepRight) / 2f, KeepBaseY - KeepFullH - 20f);
+        canvas.Save(); canvas.Translate((KeepLeft + KeepRight) / 2f, KeepBaseY - KeepFullH - 20f); _keepProgressText.Draw(canvas); canvas.Restore();
     }
 
     // ── Walls ─────────────────────────────────────────────────────────────
@@ -866,12 +866,14 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
 
                 _wallBlockSprite.HPRatio = block.HP / block.MaxHP;
                 _wallBlockSprite.Flash = flash;
-                _wallBlockSprite.Draw(canvas, wall.LeftX, blockY);
+                canvas.Save(); canvas.Translate(wall.LeftX, blockY); _wallBlockSprite.Draw(canvas); canvas.Restore();
                 blockY -= BlockH;
             }
 
             if (wall.HasArcher && !wall.IsDestroyed)
-                _archerSprite.Draw(canvas, wall.ArcherCenterX, wall.ArcherBaseY);
+            {
+                canvas.Save(); canvas.Translate(wall.ArcherCenterX, wall.ArcherBaseY); _archerSprite.Draw(canvas); canvas.Restore();
+            }
         }
     }
 
@@ -882,7 +884,9 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         float workerAreaW = KeepRight - KeepLeft - 10f;
         float spacing = workerAreaW / Math.Max(_workerCount, 1);
         for (int w = 0; w < _workerCount; w++)
-            _workerSprite.Draw(canvas, KeepLeft + 8f + w * spacing, GroundY);
+        {
+            canvas.Save(); canvas.Translate(KeepLeft + 8f + w * spacing, GroundY); _workerSprite.Draw(canvas); canvas.Restore();
+        }
     }
 
     // ── Lord ──────────────────────────────────────────────────────────────
@@ -891,7 +895,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     {
         _lordSprite.Active = _lordActive;
         _lordSprite.HPRatio = _lordHP / 10f;
-        _lordSprite.Draw(canvas, LordStandX, GroundY);
+        canvas.Save(); canvas.Translate(LordStandX, GroundY); _lordSprite.Draw(canvas); canvas.Restore();
     }
 
     // ── Enemies ───────────────────────────────────────────────────────────
@@ -902,7 +906,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         {
             if (!e.Active) continue;
             e.Sprite.HP = e.HP;
-            e.Sprite.Draw(canvas, e.X, e.Y);
+            canvas.Save(); canvas.Translate(e.X, e.Y); e.Sprite.Draw(canvas); canvas.Restore();
         }
     }
 
@@ -916,7 +920,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             a.Sprite.IsEnemy = a.IsEnemy;
             a.Sprite.VelocityX = a.Rigidbody.VelocityX;
             a.Sprite.VelocityY = a.Rigidbody.VelocityY;
-            a.Sprite.Draw(canvas, a.X, a.Y);
+            canvas.Save(); canvas.Translate(a.X, a.Y); a.Sprite.Draw(canvas); canvas.Restore();
         }
     }
 
@@ -925,7 +929,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         foreach (var b in boulders)
         {
             if (!b.Active) continue;
-            b.Sprite.Draw(canvas, b.X, b.Y);
+            canvas.Save(); canvas.Translate(b.X, b.Y); b.Sprite.Draw(canvas); canvas.Restore();
         }
     }
 
@@ -986,29 +990,29 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
     private void DrawHud(SKCanvas canvas)
     {
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, 8f, 26f);
+        canvas.Save(); canvas.Translate(8f, 26f); _scoreText.Draw(canvas); canvas.Restore();
 
         _levelText.Text = $"Level {state.Level}";
-        _levelText.Draw(canvas, GameWidth - 8f, 26f);
+        canvas.Save(); canvas.Translate(GameWidth - 8f, 26f); _levelText.Draw(canvas); canvas.Restore();
 
         _archerText.Text = $"Archers: {_archerCount}";
-        _archerText.Draw(canvas, 8f, 50f);
+        canvas.Save(); canvas.Translate(8f, 50f); _archerText.Draw(canvas); canvas.Restore();
         _workerText.Text = $"Workers: {_workerCount}";
-        _workerText.Draw(canvas, 8f, 70f);
+        canvas.Save(); canvas.Translate(8f, 70f); _workerText.Draw(canvas); canvas.Restore();
 
         float barX = 8f, barY = 82f, barW = 140f, barH = 10f;
         canvas.DrawRect(SKRect.Create(barX, barY, barW, barH), HudBarBg);
         canvas.DrawRect(SKRect.Create(barX, barY, barW * _keepProgress, barH), HudBarFg);
-        _keepLabel.Draw(canvas, barX, barY - 3f);
+        canvas.Save(); canvas.Translate(barX, barY - 3f); _keepLabel.Draw(canvas); canvas.Restore();
 
         _aimText.Text = $"Aim: {_aimAngle:F0}°";
-        _aimText.Draw(canvas, GameWidth / 2f, 20f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 20f); _aimText.Draw(canvas); canvas.Restore();
 
         if (_arrowCooldown.Active)
         {
             float r = _arrowCooldown.Remaining / ArrowCooldownTime;
             _cooldownDot.Color = new SKColor(0xFF, 0xFF, 0xFF, (byte)(r * 200));
-            _cooldownDot.Draw(canvas, GameWidth / 2f, 38f);
+            canvas.Save(); canvas.Translate(GameWidth / 2f, 38f); _cooldownDot.Draw(canvas); canvas.Restore();
         }
 
         if (_lordActive)
@@ -1016,13 +1020,13 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             float ratio = _lordHP / 10f;
             _lordHpText.Text = $"Lord HP: {_lordHP:F0}";
             _lordHpText.Color = ratio < 0.3f ? ColRed : ColGold;
-            _lordHpText.Draw(canvas, GameWidth - 160f, 50f);
+            canvas.Save(); canvas.Translate(GameWidth - 160f, 50f); _lordHpText.Draw(canvas); canvas.Restore();
         }
 
         if (_archerCount == 1 && _accuracyMult > 1)
         {
             _accuracyText.Text = $"Accuracy ×{_accuracyMult}";
-            _accuracyText.Draw(canvas, GameWidth / 2f, 60f);
+            canvas.Save(); canvas.Translate(GameWidth / 2f, 60f); _accuracyText.Draw(canvas); canvas.Restore();
         }
 
         DrawTouchButtons(canvas);
@@ -1055,7 +1059,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
         _buttonSprite.LabelColor = labelCol;
         _buttonSprite.Pressed = pressed;
         _buttonSprite.Large = large;
-        _buttonSprite.Draw(canvas, 0f, 0f);
+        _buttonSprite.Draw(canvas);
     }
 
     // ── Float texts ───────────────────────────────────────────────────────
@@ -1067,7 +1071,7 @@ internal sealed class PlayScreen(CastleAttackGameState state, IScreenCoordinator
             t.Sprite.Text = t.Text;
             t.Sprite.Color = t.Color;
             t.Sprite.Life = t.Life;
-            t.Sprite.Draw(canvas, t.X, t.Y);
+            canvas.Save(); canvas.Translate(t.X, t.Y); t.Sprite.Draw(canvas); canvas.Restore();
         }
     }
 }

--- a/src/CastleAttack/RollingLog.cs
+++ b/src/CastleAttack/RollingLog.cs
@@ -1,0 +1,20 @@
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.CastleAttack.CastleAttackConstants;
+
+namespace SkiaSharpGames.CastleAttack;
+
+/// <summary>A flaming log that rolls rightward from the walls, damaging enemies in its path.</summary>
+internal sealed class RollingLog : Entity
+{
+    public RollingLog(float x)
+    {
+        X = x;
+        Y = GroundY - LogHeight / 2f;
+        Collider = new RectCollider { Width = LogWidth, Height = LogHeight };
+        Rigidbody = new Rigidbody2D { VelocityX = LogSpeed };
+        Sprite = new RollingLogSprite();
+    }
+
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
+}

--- a/src/CastleAttack/RollingLogSprite.cs
+++ b/src/CastleAttack/RollingLogSprite.cs
@@ -1,0 +1,40 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.CastleAttack.CastleAttackConstants;
+
+namespace SkiaSharpGames.CastleAttack;
+
+/// <summary>Draws a rolling log as a brown rounded rectangle with wood grain lines.</summary>
+internal sealed class RollingLogSprite : Sprite
+{
+    public float RollAngle;
+
+    private static readonly SKPaint WoodPaint = new() { Color = ColLog, IsAntialias = true };
+    private static readonly SKPaint GrainPaint = new() { Color = new SKColor(0x6B, 0x44, 0x1E), StrokeWidth = 1f, IsAntialias = true };
+    private static readonly SKPaint EndPaint = new() { Color = new SKColor(0xA0, 0x72, 0x3A), IsAntialias = true };
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible) return;
+
+        float hw = LogWidth / 2f;
+        float hh = LogHeight / 2f;
+
+        // Main body
+        canvas.DrawRoundRect(-hw, -hh, LogWidth, LogHeight, 5f, 5f, WoodPaint);
+
+        // Wood grain
+        canvas.DrawLine(-hw + 4f, -hh + 2f, -hw + 4f, hh - 2f, GrainPaint);
+        canvas.DrawLine(0f, -hh + 2f, 0f, hh - 2f, GrainPaint);
+        canvas.DrawLine(hw - 4f, -hh + 2f, hw - 4f, hh - 2f, GrainPaint);
+
+        // End circles for rolling effect
+        canvas.DrawCircle(-hw + 2f, 0f, hh - 1f, EndPaint);
+        canvas.DrawCircle(hw - 2f, 0f, hh - 1f, EndPaint);
+    }
+
+    public override void Update(float deltaTime)
+    {
+        RollAngle += LogSpeed * deltaTime * 0.1f;
+    }
+}

--- a/src/CastleAttack/StartScreen.cs
+++ b/src/CastleAttack/StartScreen.cs
@@ -20,7 +20,7 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
     private readonly TextSprite _subtitle = new() { Text = "Defend the castle until the keep is complete!", Size = 22f, Color = ColHud, Align = TextAlign.Center };
     private readonly TextSprite _tapLine = new() { Text = "Tap the battlefield to aim & fire", Size = 17f, Color = ColAccent, Align = TextAlign.Center };
     private readonly TextSprite _btnLine = new() { Text = "Use the on-screen buttons at the bottom for all actions", Size = 16f, Color = ColDim, Align = TextAlign.Center };
-    private readonly TextSprite _kbLine = new() { Text = "Keyboard: ← → aim  |  SPACE fire  |  ↑↓ convert  |  Z X C weapons", Size = 14f, Color = ColDim, Align = TextAlign.Center };
+    private readonly TextSprite _kbLine = new() { Text = "Keyboard: LEFT RIGHT aim  |  SPACE fire  |  UP DN convert  |  Z X C weapons", Size = 14f, Color = ColDim, Align = TextAlign.Center };
     private readonly TextSprite _startLine = new() { Text = "Tap or Click to Start", Size = 24f, Color = ColAccent, Align = TextAlign.Center };
 
     static StartScreen()

--- a/src/CastleAttack/StartScreen.cs
+++ b/src/CastleAttack/StartScreen.cs
@@ -49,17 +49,17 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), OverlayPaint);
 
         float cx = GameWidth / 2f;
-        _title.Draw(canvas, cx, 190f);
-        _subtitle.Draw(canvas, cx, 258f);
+        canvas.Save(); canvas.Translate(cx, 190f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 258f); _subtitle.Draw(canvas); canvas.Restore();
 
         float y = 308f;
-        _tapLine.Draw(canvas, cx, y);
+        canvas.Save(); canvas.Translate(cx, y); _tapLine.Draw(canvas); canvas.Restore();
         y += 26f;
-        _btnLine.Draw(canvas, cx, y);
+        canvas.Save(); canvas.Translate(cx, y); _btnLine.Draw(canvas); canvas.Restore();
         y += 26f;
-        _kbLine.Draw(canvas, cx, y);
+        canvas.Save(); canvas.Translate(cx, y); _kbLine.Draw(canvas); canvas.Restore();
 
-        _startLine.Draw(canvas, cx, 420f);
+        canvas.Save(); canvas.Translate(cx, 420f); _startLine.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y)

--- a/src/CastleAttack/VictoryScreen.cs
+++ b/src/CastleAttack/VictoryScreen.cs
@@ -23,11 +23,11 @@ internal sealed class VictoryScreen(CastleAttackGameState state, IScreenCoordina
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), OverlayPaint);
 
         float cx = GameWidth / 2f;
-        _victoryText.Draw(canvas, cx, 250f);
+        canvas.Save(); canvas.Translate(cx, 250f); _victoryText.Draw(canvas); canvas.Restore();
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, cx, 315f);
-        _keepText.Draw(canvas, cx, 360f);
-        _playAgainText.Draw(canvas, cx, 395f);
+        canvas.Save(); canvas.Translate(cx, 315f); _scoreText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 360f); _keepText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 395f); _playAgainText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y)

--- a/src/CastleAttack/WallBlockSprite.cs
+++ b/src/CastleAttack/WallBlockSprite.cs
@@ -14,7 +14,7 @@ internal sealed class WallBlockSprite : Sprite
     private static readonly SKPaint CrackPaint = new() { Color = new SKColor(0x00, 0x00, 0x00, 80), StrokeWidth = 1.5f, IsAntialias = true };
     private static readonly SKPaint ShinePaint = new() { Color = SKColors.White.WithAlpha(40), IsAntialias = true };
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible) return;
 
@@ -24,11 +24,11 @@ internal sealed class WallBlockSprite : Sprite
                     : ColStone;
 
         BlockPaint.Color = col;
-        canvas.DrawRoundRect(SKRect.Create(x, y, BlockW, BlockH), 3f, 3f, BlockPaint);
+        canvas.DrawRoundRect(SKRect.Create(0f, 0f, BlockW, BlockH), 3f, 3f, BlockPaint);
 
         if (HPRatio < 0.6f)
-            canvas.DrawLine(x + 8f, y + 4f, x + 18f, y + BlockH - 4f, CrackPaint);
+            canvas.DrawLine(0f + 8f, 0f + 4f, 0f + 18f, 0f + BlockH - 4f, CrackPaint);
 
-        canvas.DrawRect(SKRect.Create(x + 2f, y + 2f, BlockW - 4f, BlockH / 2f - 2f), ShinePaint);
+        canvas.DrawRect(SKRect.Create(0f + 2f, 0f + 2f, BlockW - 4f, BlockH / 2f - 2f), ShinePaint);
     }
 }

--- a/src/CastleAttack/WorkerSprite.cs
+++ b/src/CastleAttack/WorkerSprite.cs
@@ -10,14 +10,12 @@ internal sealed class WorkerSprite : Sprite
     private static readonly SKPaint BodyPaint = new() { Color = ColWorker, IsAntialias = true };
     private static readonly SKPaint ToolPaint = new() { Color = new SKColor(0xCC, 0xCC, 0xCC), StrokeWidth = 2f, IsAntialias = true };
 
-    /// <param name="x">Centre X of the worker.</param>
-    /// <param name="y">Base Y (feet) of the worker.</param>
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible) return;
 
-        canvas.DrawRect(SKRect.Create(x - WorkerW / 2f, y - WorkerH, WorkerW, WorkerH - 6f), BodyPaint);
-        canvas.DrawCircle(x, y - WorkerH - 4f, 5f, BodyPaint);
-        canvas.DrawLine(x + WorkerW / 2f, y - WorkerH + 2f, x + WorkerW / 2f + 10f, y - WorkerH + 10f, ToolPaint);
+        canvas.DrawRect(SKRect.Create(0f - WorkerW / 2f, 0f - WorkerH, WorkerW, WorkerH - 6f), BodyPaint);
+        canvas.DrawCircle(0f, 0f - WorkerH - 4f, 5f, BodyPaint);
+        canvas.DrawLine(0f + WorkerW / 2f, 0f - WorkerH + 2f, 0f + WorkerW / 2f + 10f, 0f - WorkerH + 10f, ToolPaint);
     }
 }

--- a/src/Catch/BarSprite.cs
+++ b/src/Catch/BarSprite.cs
@@ -19,13 +19,13 @@ internal sealed class BarSprite : Sprite
 
     public bool ShowShine { get; set; } = true;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
 
-        float left = x - Width / 2f;
-        float top = y - Height / 2f;
+        float left = 0f - Width / 2f;
+        float top = 0f - Height / 2f;
         var rect = SKRect.Create(left, top, Width, Height);
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));

--- a/src/Catch/CircleSprite.cs
+++ b/src/Catch/CircleSprite.cs
@@ -18,7 +18,7 @@ internal sealed class CircleSprite : Sprite
 
     public SKColor GlowColor { get; set; } = AccentColor;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
@@ -27,11 +27,11 @@ internal sealed class CircleSprite : Sprite
         {
             EnsureGlowMask();
             _glowPaint.Color = GlowColor.WithAlpha((byte)(60 * Alpha));
-            canvas.DrawCircle(x, y, Radius + GlowRadius / 2f, _glowPaint);
+            canvas.DrawCircle(0f, 0f, Radius + GlowRadius / 2f, _glowPaint);
         }
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
-        canvas.DrawCircle(x, y, Radius, _paint);
+        canvas.DrawCircle(0f, 0f, Radius, _paint);
     }
 
     private void EnsureGlowMask()

--- a/src/Catch/FallingCircle.cs
+++ b/src/Catch/FallingCircle.cs
@@ -1,4 +1,3 @@
-using SkiaSharp;
 using SkiaSharpGames.GameEngine;
 using static SkiaSharpGames.Catch.CatchConstants;
 
@@ -6,9 +5,14 @@ namespace SkiaSharpGames.Catch;
 
 internal sealed class FallingCircle : Entity
 {
-    public readonly CircleCollider Collider = new() { Radius = CircleRadius };
+    public FallingCircle()
+    {
+        Collider = new CircleCollider { Radius = CircleRadius };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new CircleSprite();
+    }
 
-    public readonly Rigidbody2D Rigidbody = new();
-
-    public readonly CircleSprite Sprite = new();
+    public new CircleSprite Sprite { get => (CircleSprite)base.Sprite!; init => base.Sprite = value; }
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 }

--- a/src/Catch/GameOverScreen.cs
+++ b/src/Catch/GameOverScreen.cs
@@ -16,12 +16,12 @@ internal sealed class GameOverScreen(CatchGameState state, IScreenCoordinator co
     {
         canvas.DrawRect(0, 0, GameWidth, GameHeight, _overlayPaint);
 
-        _titleText.Draw(canvas, GameWidth / 2f, 250f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 250f); _titleText.Draw(canvas); canvas.Restore();
 
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 325f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 325f); _scoreText.Draw(canvas); canvas.Restore();
 
-        _promptText.Draw(canvas, GameWidth / 2f, 395f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 395f); _promptText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/Catch/PlayScreen.cs
+++ b/src/Catch/PlayScreen.cs
@@ -73,10 +73,10 @@ internal sealed class PlayScreen(CatchGameState state, IScreenCoordinator coordi
         if (_rightHeld)
             MoveBarTo(_bar.X + BarSpeed * deltaTime);
 
-        _circle.Rigidbody.Step(_circle, deltaTime);
+        _circle.Update(deltaTime);
 
         if (_circle.Rigidbody.VelocityY > 0f &&
-            CollisionResolver.TryGetHit(_circle.X, _circle.Y, _circle.Collider, _bar.X, _bar.Y, _bar.Collider, out _))
+            _circle.TryGetHit(_bar, out _))
         {
             state.Score++;
             _fallSpeed += FallSpeedIncrement;
@@ -107,8 +107,8 @@ internal sealed class PlayScreen(CatchGameState state, IScreenCoordinator coordi
         _fillPaint.Color = SKColors.White.WithAlpha((byte)(255 * 0.09f));
         canvas.DrawRect(SKRect.Create(0f, BarY + BarHeight / 2f + 20f, GameWidth, 3f), _fillPaint);
 
-        canvas.Save(); canvas.Translate(_bar.X, _bar.Y); _bar.Sprite.Draw(canvas); canvas.Restore();
-        canvas.Save(); canvas.Translate(_circle.X, _circle.Y); _circle.Sprite.Draw(canvas); canvas.Restore();
+        _bar.Draw(canvas);
+        _circle.Draw(canvas);
 
         // HUD
         _scoreText.Text = $"Score: {state.Score}";

--- a/src/Catch/PlayScreen.cs
+++ b/src/Catch/PlayScreen.cs
@@ -76,7 +76,7 @@ internal sealed class PlayScreen(CatchGameState state, IScreenCoordinator coordi
         _circle.Rigidbody.Step(_circle, deltaTime);
 
         if (_circle.Rigidbody.VelocityY > 0f &&
-            CollisionResolver.TryGetHit(_circle, _circle.Collider, _bar, _bar.Collider, out _))
+            CollisionResolver.TryGetHit(_circle.X, _circle.Y, _circle.Collider, _bar.X, _bar.Y, _bar.Collider, out _))
         {
             state.Score++;
             _fallSpeed += FallSpeedIncrement;
@@ -107,18 +107,18 @@ internal sealed class PlayScreen(CatchGameState state, IScreenCoordinator coordi
         _fillPaint.Color = SKColors.White.WithAlpha((byte)(255 * 0.09f));
         canvas.DrawRect(SKRect.Create(0f, BarY + BarHeight / 2f + 20f, GameWidth, 3f), _fillPaint);
 
-        _bar.Sprite.Draw(canvas, _bar.X, _bar.Y);
-        _circle.Sprite.Draw(canvas, _circle.X, _circle.Y);
+        canvas.Save(); canvas.Translate(_bar.X, _bar.Y); _bar.Sprite.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(_circle.X, _circle.Y); _circle.Sprite.Draw(canvas); canvas.Restore();
 
         // HUD
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, 20f, 35f);
+        canvas.Save(); canvas.Translate(20f, 35f); _scoreText.Draw(canvas); canvas.Restore();
 
         _livesText.Text = $"Lives: {state.Lives}";
         _livesText.Color = state.Lives == 1 ? DangerColor : SKColors.White;
-        _livesText.Draw(canvas, GameWidth - 20f, 35f);
+        canvas.Save(); canvas.Translate(GameWidth - 20f, 35f); _livesText.Draw(canvas); canvas.Restore();
 
-        _instructionsText.Draw(canvas, GameWidth / 2f, 34f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 34f); _instructionsText.Draw(canvas); canvas.Restore();
     }
 
     private void MoveBarTo(float x)

--- a/src/Catch/PlayerBar.cs
+++ b/src/Catch/PlayerBar.cs
@@ -4,7 +4,12 @@ namespace SkiaSharpGames.Catch;
 
 internal sealed class PlayerBar : Entity
 {
-    public readonly RectCollider Collider = new() { Width = CatchConstants.BarWidth, Height = CatchConstants.BarHeight };
+    public PlayerBar()
+    {
+        Collider = new RectCollider { Width = CatchConstants.BarWidth, Height = CatchConstants.BarHeight };
+        Sprite = new BarSprite();
+    }
 
-    public readonly BarSprite Sprite = new();
+    public new BarSprite Sprite { get => (BarSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
 }

--- a/src/Catch/StartScreen.cs
+++ b/src/Catch/StartScreen.cs
@@ -17,12 +17,12 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
     {
         canvas.Clear(BackgroundColor);
 
-        _title.Draw(canvas, GameWidth / 2f, 225f);
-        _subtitle.Draw(canvas, GameWidth / 2f, 285f);
-        _instruction1.Draw(canvas, GameWidth / 2f, 350f);
-        _instruction2.Draw(canvas, GameWidth / 2f, 382f);
-        _instruction3.Draw(canvas, GameWidth / 2f, 414f);
-        _startPrompt.Draw(canvas, GameWidth / 2f, 474f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 225f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 285f); _subtitle.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 350f); _instruction1.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 382f); _instruction2.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 414f); _instruction3.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 474f); _startPrompt.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/GameEngine/Entity.cs
+++ b/src/GameEngine/Entity.cs
@@ -1,18 +1,289 @@
+using SkiaSharp;
+
 namespace SkiaSharpGames.GameEngine;
 
 /// <summary>
-/// Abstract base for all game objects that exist in the game world.
-/// An entity is the single source of truth for position; physics and rendering
-/// components read from it rather than storing their own copy.
+/// Base class for all game objects. An entity carries position (with optional
+/// rotation), nullable rendering/physics/collision components, and an ordered
+/// list of children. Children store local-space positions relative to their
+/// parent; world positions are cached and recalculated whenever any ancestor's
+/// local position or rotation changes.
 /// </summary>
-public abstract class Entity
+public class Entity
 {
-    /// <summary>Horizontal centre position in game-space units.</summary>
-    public float X { get; set; }
+    private float _x, _y, _rotation;
+    private List<Entity>? _children;
 
-    /// <summary>Vertical centre position in game-space units.</summary>
-    public float Y { get; set; }
+    // ── Local position / rotation ─────────────────────────────────────
+
+    /// <summary>Horizontal position in local space (relative to parent, or world if root).</summary>
+    public float X
+    {
+        get => _x;
+        set { _x = value; RecalculateWorld(); }
+    }
+
+    /// <summary>Vertical position in local space (relative to parent, or world if root).</summary>
+    public float Y
+    {
+        get => _y;
+        set { _y = value; RecalculateWorld(); }
+    }
+
+    /// <summary>Local rotation in radians. Positive = clockwise.</summary>
+    public float Rotation
+    {
+        get => _rotation;
+        set { _rotation = value; RecalculateWorld(); }
+    }
 
     /// <summary>When <see langword="false"/> the entity is skipped during update and rendering.</summary>
     public bool Active { get; set; } = true;
+
+    /// <summary>When <see langword="false"/> the entity is not drawn (but still updated).</summary>
+    public bool Visible { get; set; } = true;
+
+    // ── World transform (cached) ──────────────────────────────────────
+
+    /// <summary>World-space X, accounting for all ancestor positions and rotations.</summary>
+    public float WorldX { get; private set; }
+
+    /// <summary>World-space Y, accounting for all ancestor positions and rotations.</summary>
+    public float WorldY { get; private set; }
+
+    /// <summary>Accumulated world rotation in radians.</summary>
+    public float WorldRotation { get; private set; }
+
+    private void RecalculateWorld()
+    {
+        if (Parent is null)
+        {
+            WorldX = _x;
+            WorldY = _y;
+            WorldRotation = _rotation;
+        }
+        else if (Parent.WorldRotation == 0f)
+        {
+            // Fast path: no parent rotation — simple addition
+            WorldX = Parent.WorldX + _x;
+            WorldY = Parent.WorldY + _y;
+            WorldRotation = _rotation;
+        }
+        else
+        {
+            // Parent rotation orbits child position around parent
+            float cos = MathF.Cos(Parent.WorldRotation);
+            float sin = MathF.Sin(Parent.WorldRotation);
+            WorldX = Parent.WorldX + _x * cos - _y * sin;
+            WorldY = Parent.WorldY + _x * sin + _y * cos;
+            WorldRotation = Parent.WorldRotation + _rotation;
+        }
+
+        if (_children is not null)
+            for (int i = 0; i < _children.Count; i++)
+                _children[i].RecalculateWorld();
+    }
+
+    // ── Components (nullable, opt-in) ─────────────────────────────────
+
+    /// <summary>Visual representation. Drawn at the local origin by <see cref="Draw"/>.</summary>
+    public Sprite? Sprite { get; set; }
+
+    /// <summary>Collision shape. Used by <see cref="WorldBoundingBox"/> and collision helpers.</summary>
+    public Collider2D? Collider { get; set; }
+
+    /// <summary>Velocity-driven movement. Stepped automatically by <see cref="Update"/>.</summary>
+    public Rigidbody2D? Rigidbody { get; set; }
+
+    // ── Children ──────────────────────────────────────────────────────
+
+    /// <summary>Parent entity, or null if this is a root entity.</summary>
+    public Entity? Parent { get; private set; }
+
+    /// <summary>Ordered list of child entities.</summary>
+    public IReadOnlyList<Entity> Children => (IReadOnlyList<Entity>?)_children ?? [];
+
+    /// <summary>Number of children.</summary>
+    public int ChildCount => _children?.Count ?? 0;
+
+    /// <summary>
+    /// Adds <paramref name="child"/> to this entity's children. If the child already
+    /// has a parent it is removed from that parent first. World positions are recalculated.
+    /// </summary>
+    public void AddChild(Entity child)
+    {
+        child.Parent?.RemoveChild(child);
+        (_children ??= []).Add(child);
+        child.Parent = this;
+        child.RecalculateWorld();
+    }
+
+    /// <summary>Removes <paramref name="child"/> from this entity's children.</summary>
+    public void RemoveChild(Entity child)
+    {
+        if (_children?.Remove(child) == true)
+        {
+            child.Parent = null;
+            child.RecalculateWorld();
+        }
+    }
+
+    /// <summary>Removes all children where <see cref="Active"/> is false.</summary>
+    public int RemoveInactiveChildren()
+    {
+        if (_children is null) return 0;
+        return _children.RemoveAll(c =>
+        {
+            if (c.Active) return false;
+            c.Parent = null;
+            return true;
+        });
+    }
+
+    // ── Update (recursive) ────────────────────────────────────────────
+
+    /// <summary>
+    /// Advances the entity tree. Steps rigidbody, updates sprite, calls
+    /// <see cref="OnUpdate"/>, then recurses into active children.
+    /// </summary>
+    public void Update(float deltaTime)
+    {
+        if (!Active) return;
+
+        Rigidbody?.Step(this, deltaTime);
+        Sprite?.Update(deltaTime);
+        OnUpdate(deltaTime);
+
+        if (_children is not null)
+            for (int i = 0; i < _children.Count; i++)
+                _children[i].Update(deltaTime);
+    }
+
+    /// <summary>Override for game-specific per-frame logic (timers, AI, etc.).</summary>
+    protected virtual void OnUpdate(float deltaTime) { }
+
+    // ── Draw (recursive) ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Renders the entity tree. Translates (and optionally rotates) the canvas,
+    /// draws the sprite at the local origin, then recurses into visible children.
+    /// </summary>
+    public void Draw(SKCanvas canvas)
+    {
+        if (!Active || !Visible) return;
+
+        canvas.Save();
+        canvas.Translate(_x, _y);
+        if (_rotation != 0f)
+            canvas.RotateRadians(_rotation);
+
+        Sprite?.Draw(canvas);
+
+        if (_children is not null)
+            for (int i = 0; i < _children.Count; i++)
+                _children[i].Draw(canvas);
+
+        canvas.Restore();
+    }
+
+    // ── Collision (world-space) ───────────────────────────────────────
+
+    /// <summary>
+    /// World-space bounding box. Returns a conservative axis-aligned box that
+    /// encloses the collider, accounting for rotation. Null if no collider.
+    /// </summary>
+    public SKRect? WorldBoundingBox
+    {
+        get
+        {
+            if (Collider is null) return null;
+            var local = Collider.BoundingBox(0f, 0f);
+
+            if (WorldRotation == 0f)
+                return SKRect.Create(WorldX + local.Left, WorldY + local.Top,
+                                     local.Width, local.Height);
+
+            // Rotated AABB: compute enclosing axis-aligned box
+            float cos = MathF.Cos(WorldRotation);
+            float sin = MathF.Sin(WorldRotation);
+            float halfW = local.Width / 2f;
+            float halfH = local.Height / 2f;
+            float absW = MathF.Abs(cos) * halfW + MathF.Abs(sin) * halfH;
+            float absH = MathF.Abs(sin) * halfW + MathF.Abs(cos) * halfH;
+            return new SKRect(WorldX - absW, WorldY - absH,
+                              WorldX + absW, WorldY + absH);
+        }
+    }
+
+    /// <summary>Tests overlap with another entity in world space.</summary>
+    public bool Overlaps(Entity other) =>
+        CollisionResolver.Overlaps(this, other);
+
+    /// <summary>Tests overlap and returns collision details for bounce resolution.</summary>
+    public bool TryGetHit(Entity other, out CollisionHit hit) =>
+        CollisionResolver.TryGetHit(this, other, out hit);
+
+    /// <summary>If overlapping, bounces this entity's rigidbody off <paramref name="other"/>.</summary>
+    public bool BounceOff(Entity other)
+    {
+        if (Rigidbody is null || !TryGetHit(other, out var hit)) return false;
+        Rigidbody.Bounce(hit);
+        return true;
+    }
+
+    // ── Child queries ─────────────────────────────────────────────────
+
+    /// <summary>Aggregate world-space bounding box of all active children with colliders.</summary>
+    public SKRect? ChildrenBoundingBox
+    {
+        get
+        {
+            if (_children is null) return null;
+            SKRect? result = null;
+            for (int i = 0; i < _children.Count; i++)
+            {
+                var c = _children[i];
+                if (!c.Active) continue;
+                var bb = c.WorldBoundingBox;
+                if (bb is null) continue;
+                result = result is null ? bb.Value : SKRect.Union(result.Value, bb.Value);
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Finds the first active child that collides with <paramref name="other"/>.
+    /// Performs a broad-phase group bounding box check first.
+    /// </summary>
+    public Entity? FindChildCollision(Entity other, out CollisionHit hit)
+    {
+        if (_children is null || other.Collider is null)
+        {
+            hit = default;
+            return null;
+        }
+
+        // Broad-phase: skip all children if other doesn't overlap group bounds
+        var groupBB = ChildrenBoundingBox;
+        var otherBB = other.WorldBoundingBox;
+        if (groupBB is null || otherBB is null
+            || !groupBB.Value.IntersectsWith(otherBB.Value))
+        {
+            hit = default;
+            return null;
+        }
+
+        // Narrow-phase: test each active child
+        for (int i = 0; i < _children.Count; i++)
+        {
+            var c = _children[i];
+            if (!c.Active || c.Collider is null) continue;
+            if (CollisionResolver.TryGetHit(other, c, out hit))
+                return c;
+        }
+
+        hit = default;
+        return null;
+    }
 }

--- a/src/GameEngine/Physics/CircleCollider.cs
+++ b/src/GameEngine/Physics/CircleCollider.cs
@@ -4,19 +4,17 @@ namespace SkiaSharpGames.GameEngine;
 
 /// <summary>
 /// A circular collision shape attached to an <see cref="Entity"/>.
-/// The entity's <see cref="Entity.X"/>/<see cref="Entity.Y"/> is the centre of the circle.
-/// <see cref="Collider2D.OffsetX"/>/<see cref="Collider2D.OffsetY"/> shift the hitbox relative
-/// to that centre.
 /// </summary>
 public sealed class CircleCollider : Collider2D
 {
     /// <summary>Radius of the circle in game-space units.</summary>
     public float Radius { get; set; }
 
-    /// <summary>World-space axis-aligned bounding box for the given <paramref name="owner"/>.</summary>
-    public override SKRect BoundingBox(Entity owner)
+    /// <inheritdoc/>
+    public override SKRect BoundingBox(float centerX, float centerY)
     {
-        var (cx, cy) = WorldCenter(owner);
+        float cx = centerX + OffsetX;
+        float cy = centerY + OffsetY;
         return new SKRect(cx - Radius, cy - Radius, cx + Radius, cy + Radius);
     }
 }

--- a/src/GameEngine/Physics/Collider2D.cs
+++ b/src/GameEngine/Physics/Collider2D.cs
@@ -4,8 +4,9 @@ namespace SkiaSharpGames.GameEngine;
 
 /// <summary>
 /// Base type for simple 2D colliders attached to an <see cref="Entity"/>.
-/// The entity remains the single source of truth for world position; the collider only
-/// describes the hit shape around that position.
+/// The collider describes the hit shape around a centre point; the entity's
+/// world position is passed to <see cref="BoundingBox"/> and used by
+/// <see cref="CollisionResolver"/>.
 /// </summary>
 public abstract class Collider2D
 {
@@ -15,10 +16,10 @@ public abstract class Collider2D
     /// <summary>Vertical offset of the collider relative to the owning entity center.</summary>
     public float OffsetY { get; set; }
 
-    /// <summary>Gets the collider center in world space.</summary>
-    public virtual (float X, float Y) WorldCenter(Entity owner) =>
-        (owner.X + OffsetX, owner.Y + OffsetY);
+    /// <summary>Gets the collider center given the entity's world position.</summary>
+    public (float X, float Y) WorldCenter(float entityX, float entityY) =>
+        (entityX + OffsetX, entityY + OffsetY);
 
     /// <summary>Gets the world-space axis-aligned bounds of the collider.</summary>
-    public abstract SKRect BoundingBox(Entity owner);
+    public abstract SKRect BoundingBox(float centerX, float centerY);
 }

--- a/src/GameEngine/Physics/CollisionResolver.cs
+++ b/src/GameEngine/Physics/CollisionResolver.cs
@@ -1,43 +1,58 @@
 namespace SkiaSharpGames.GameEngine;
 
 /// <summary>
-/// Static helpers for simple arcade-style 2D collisions between entities, colliders, and
-/// rigidbodies.
+/// Static helpers for simple arcade-style 2D collisions between entities.
 /// </summary>
 public static class CollisionResolver
 {
-    // ── Entity + collider API ─────────────────────────────────────────────
+    // ── Entity API (uses WorldX/WorldY and Collider) ──────────────────
 
     /// <summary>
-    /// Returns <see langword="true"/> when the two colliders overlap.
+    /// Returns <see langword="true"/> when the two entities' colliders overlap
+    /// in world space. Returns false if either entity has no collider.
     /// </summary>
-    public static bool Overlaps(Entity a, Collider2D colliderA, Entity b, Collider2D colliderB) =>
-        TryGetHit(a, colliderA, b, colliderB, out _);
+    public static bool Overlaps(Entity a, Entity b)
+    {
+        if (a.Collider is null || b.Collider is null) return false;
+        return TryGetHit(a.WorldX, a.WorldY, a.Collider,
+                         b.WorldX, b.WorldY, b.Collider, out _);
+    }
 
     /// <summary>
-    /// Returns <see langword="true"/> when the circle described by
-    /// <paramref name="circle"/>/<paramref name="circleOwner"/> overlaps the rectangle described by
-    /// <paramref name="rect"/>/<paramref name="rectOwner"/>.
+    /// Returns <see langword="true"/> when the two entities overlap and outputs
+    /// <paramref name="hit"/> with the collision normal and penetration.
+    /// Returns false if either entity has no collider.
     /// </summary>
-    public static bool Overlaps(Entity circleOwner, CircleCollider circle,
-                                Entity rectOwner,   RectCollider rect)
-        => TryGetHit(circleOwner, circle, rectOwner, rect, out _);
+    public static bool TryGetHit(Entity a, Entity b, out CollisionHit hit)
+    {
+        if (a.Collider is null || b.Collider is null)
+        {
+            hit = default;
+            return false;
+        }
+        return TryGetHit(a.WorldX, a.WorldY, a.Collider,
+                         b.WorldX, b.WorldY, b.Collider, out hit);
+    }
+
+    // ── Position-based API ────────────────────────────────────────────
 
     /// <summary>
-    /// Tries to compute collision information for the two supplied colliders.
+    /// Tries to compute collision information for two colliders at explicit positions.
     /// </summary>
-    public static bool TryGetHit(Entity a, Collider2D colliderA, Entity b, Collider2D colliderB, out CollisionHit hit)
+    public static bool TryGetHit(float ax, float ay, Collider2D colliderA,
+                                 float bx, float by, Collider2D colliderB,
+                                 out CollisionHit hit)
     {
         switch (colliderA)
         {
             case CircleCollider circleA when colliderB is CircleCollider circleB:
-                return TryGetCircleCircleHit(a, circleA, b, circleB, out hit);
+                return TryGetCircleCircleHit(ax, ay, circleA, bx, by, circleB, out hit);
 
             case CircleCollider circle when colliderB is RectCollider rect:
-                return TryGetCircleRectHit(a, circle, b, rect, out hit);
+                return TryGetCircleRectHit(ax, ay, circle, bx, by, rect, out hit);
 
             case RectCollider rectA when colliderB is CircleCollider circleB:
-                if (TryGetCircleRectHit(b, circleB, a, rectA, out var reverseHit))
+                if (TryGetCircleRectHit(bx, by, circleB, ax, ay, rectA, out var reverseHit))
                 {
                     hit = new CollisionHit(-reverseHit.NormalX, -reverseHit.NormalY, reverseHit.Penetration);
                     return true;
@@ -46,47 +61,21 @@ public static class CollisionResolver
                 return false;
 
             case RectCollider rectA when colliderB is RectCollider rectB:
-                return TryGetRectRectHit(a, rectA, b, rectB, out hit);
+                return TryGetRectRectHit(ax, ay, rectA, bx, by, rectB, out hit);
 
             default:
                 throw new NotSupportedException($"Unsupported collider pair: {colliderA.GetType().Name} and {colliderB.GetType().Name}.");
         }
     }
 
-    /// <summary>
-    /// Reflects <paramref name="rigidbody"/>'s velocity off the rectangle
-    /// <paramref name="rect"/>/<paramref name="rectOwner"/> using the smallest-overlap axis.
-    /// Does <b>not</b> check for overlap first.
-    /// </summary>
-    public static void Reflect(Entity circleOwner, CircleCollider circle, Rigidbody2D rigidbody,
-                               Entity rectOwner,   RectCollider rect)
+    private static bool TryGetCircleCircleHit(float ax, float ay, CircleCollider circleA,
+                                               float bx, float by, CircleCollider circleB,
+                                               out CollisionHit hit)
     {
-        if (TryGetHit(circleOwner, circle, rectOwner, rect, out var hit))
-            rigidbody.Bounce(hit);
-    }
-
-    /// <summary>
-    /// If the circle overlaps the rectangle, reflects <paramref name="rigidbody"/>'s velocity
-    /// and returns <see langword="true"/>. Returns <see langword="false"/> when there is no overlap.
-    /// </summary>
-    public static bool ReflectOff(Entity circleOwner, CircleCollider circle, Rigidbody2D rigidbody,
-                                  Entity rectOwner,   RectCollider rect)
-    {
-        if (!TryGetHit(circleOwner, circle, rectOwner, rect, out var hit))
-            return false;
-
-        rigidbody.Bounce(hit);
-        return true;
-    }
-
-    private static bool TryGetCircleCircleHit(Entity a, CircleCollider circleA,
-                                              Entity b, CircleCollider circleB,
-                                              out CollisionHit hit)
-    {
-        var (ax, ay) = circleA.WorldCenter(a);
-        var (bx, by) = circleB.WorldCenter(b);
-        float dx = ax - bx;
-        float dy = ay - by;
+        var (cax, cay) = circleA.WorldCenter(ax, ay);
+        var (cbx, cby) = circleB.WorldCenter(bx, by);
+        float dx = cax - cbx;
+        float dy = cay - cby;
         float distanceSquared = dx * dx + dy * dy;
         float radius = circleA.Radius + circleB.Radius;
         float radiusSquared = radius * radius;
@@ -108,12 +97,12 @@ public static class CollisionResolver
         return true;
     }
 
-    private static bool TryGetRectRectHit(Entity a, RectCollider rectA,
-                                          Entity b, RectCollider rectB,
-                                          out CollisionHit hit)
+    private static bool TryGetRectRectHit(float ax, float ay, RectCollider rectA,
+                                           float bx, float by, RectCollider rectB,
+                                           out CollisionHit hit)
     {
-        var aBounds = rectA.WorldRect(a);
-        var bBounds = rectB.WorldRect(b);
+        var aBounds = rectA.WorldRect(ax, ay);
+        var bBounds = rectB.WorldRect(bx, by);
 
         if (!aBounds.IntersectsWith(bBounds))
         {
@@ -123,25 +112,25 @@ public static class CollisionResolver
 
         float overlapX = MathF.Min(aBounds.Right, bBounds.Right) - MathF.Max(aBounds.Left, bBounds.Left);
         float overlapY = MathF.Min(aBounds.Bottom, bBounds.Bottom) - MathF.Max(aBounds.Top, bBounds.Top);
-        var (ax, ay) = rectA.WorldCenter(a);
-        var (bx, by) = rectB.WorldCenter(b);
+        var (cax, cay) = rectA.WorldCenter(ax, ay);
+        var (cbx, cby) = rectB.WorldCenter(bx, by);
 
         if (overlapX < overlapY)
         {
-            hit = new CollisionHit(ax < bx ? -1f : 1f, 0f, overlapX);
+            hit = new CollisionHit(cax < cbx ? -1f : 1f, 0f, overlapX);
             return true;
         }
 
-        hit = new CollisionHit(0f, ay < by ? -1f : 1f, overlapY);
+        hit = new CollisionHit(0f, cay < cby ? -1f : 1f, overlapY);
         return true;
     }
 
-    private static bool TryGetCircleRectHit(Entity circleOwner, CircleCollider circle,
-                                            Entity rectOwner, RectCollider rect,
-                                            out CollisionHit hit)
+    private static bool TryGetCircleRectHit(float circleX, float circleY, CircleCollider circle,
+                                             float rectX, float rectY, RectCollider rect,
+                                             out CollisionHit hit)
     {
-        var (cx, cy) = circle.WorldCenter(circleOwner);
-        var bounds = rect.WorldRect(rectOwner);
+        var (cx, cy) = circle.WorldCenter(circleX, circleY);
+        var bounds = rect.WorldRect(rectX, rectY);
         float nearX = Math.Clamp(cx, bounds.Left, bounds.Right);
         float nearY = Math.Clamp(cy, bounds.Top, bounds.Bottom);
         float dx = cx - nearX;

--- a/src/GameEngine/Physics/RectCollider.cs
+++ b/src/GameEngine/Physics/RectCollider.cs
@@ -4,9 +4,6 @@ namespace SkiaSharpGames.GameEngine;
 
 /// <summary>
 /// An axis-aligned rectangular collision shape attached to an <see cref="Entity"/>.
-/// The entity's <see cref="Entity.X"/>/<see cref="Entity.Y"/> is the centre of the rectangle.
-/// <see cref="Collider2D.OffsetX"/>/<see cref="Collider2D.OffsetY"/> shift the hitbox relative
-/// to that centre.
 /// </summary>
 public sealed class RectCollider : Collider2D
 {
@@ -16,12 +13,13 @@ public sealed class RectCollider : Collider2D
     /// <summary>Height of the rectangle in game-space units.</summary>
     public float Height { get; set; }
 
-    /// <summary>World-space axis-aligned bounding box for the given <paramref name="owner"/>.</summary>
-    public SKRect WorldRect(Entity owner) => SKRect.Create(
-        owner.X + OffsetX - Width / 2f,
-        owner.Y + OffsetY - Height / 2f,
+    /// <summary>World-space rectangle given an entity centre position.</summary>
+    public SKRect WorldRect(float centerX, float centerY) => SKRect.Create(
+        centerX + OffsetX - Width / 2f,
+        centerY + OffsetY - Height / 2f,
         Width, Height);
 
-    /// <summary>World-space axis-aligned bounding box for the given <paramref name="owner"/>.</summary>
-    public override SKRect BoundingBox(Entity owner) => WorldRect(owner);
+    /// <inheritdoc/>
+    public override SKRect BoundingBox(float centerX, float centerY) =>
+        WorldRect(centerX, centerY);
 }

--- a/src/GameEngine/Sprite.cs
+++ b/src/GameEngine/Sprite.cs
@@ -4,9 +4,9 @@ namespace SkiaSharpGames.GameEngine;
 
 /// <summary>
 /// Base class for all drawable game sprites.
-/// A sprite encapsulates visual appearance only — position is not stored here.
-/// Callers pass the position at draw time so that the entity remains the single
-/// source of truth for where things are.
+/// A sprite draws at the canvas origin (0, 0) — the entity's <see cref="Entity.Draw"/>
+/// method translates the canvas to the entity's position before calling
+/// <see cref="Draw(SKCanvas)"/>.
 /// </summary>
 public abstract class Sprite
 {
@@ -17,10 +17,10 @@ public abstract class Sprite
     public bool Visible { get; set; } = true;
 
     /// <summary>
-    /// Renders the sprite onto <paramref name="canvas"/> centred on
-    /// (<paramref name="x"/>, <paramref name="y"/>) in game-space units.
+    /// Renders the sprite onto <paramref name="canvas"/> centred at the canvas origin.
+    /// The canvas has already been translated to the entity's position.
     /// </summary>
-    public abstract void Draw(SKCanvas canvas, float x, float y);
+    public abstract void Draw(SKCanvas canvas);
 
     /// <summary>
     /// Advances any animated properties by <paramref name="deltaTime"/> seconds.

--- a/src/GameEngine/TextSprite.cs
+++ b/src/GameEngine/TextSprite.cs
@@ -43,7 +43,7 @@ public sealed class TextSprite : Sprite
     }
 
     /// <inheritdoc />
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f || string.IsNullOrEmpty(Text))
             return;
@@ -53,12 +53,12 @@ public sealed class TextSprite : Sprite
 
         float drawX = Align switch
         {
-            TextAlign.Center => x - font.MeasureText(Text) / 2f,
-            TextAlign.Right => x - font.MeasureText(Text),
-            _ => x
+            TextAlign.Center => -font.MeasureText(Text) / 2f,
+            TextAlign.Right => -font.MeasureText(Text),
+            _ => 0f
         };
 
-        canvas.DrawText(Text, drawX, y, font, _paint);
+        canvas.DrawText(Text, drawX, 0f, font, _paint);
     }
 
     private static SKFont GetFont(float size)

--- a/src/LunarLander/FlameSprite.cs
+++ b/src/LunarLander/FlameSprite.cs
@@ -1,0 +1,52 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.LunarLander.LunarLanderConstants;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>Draws a flickering thruster flame at origin pointing downward in local space.</summary>
+internal sealed class FlameSprite : Sprite
+{
+    private readonly SKPaint _outerPaint = new() { IsAntialias = true, Style = SKPaintStyle.Fill };
+    private readonly SKPaint _innerPaint = new() { IsAntialias = true, Style = SKPaintStyle.Fill };
+
+    private float _flicker;
+
+    /// <summary>Controls the size of the flame (0–1).</summary>
+    public float Intensity { get; set; } = 1f;
+
+    public override void Update(float deltaTime)
+    {
+        _flicker = 0.8f + 0.2f * MathF.Sin(Environment.TickCount * 0.03f + GetHashCode());
+    }
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible || Alpha <= 0f || Intensity <= 0f)
+            return;
+
+        byte alpha = (byte)(220 * Alpha);
+        float length = 8f + 10f * Intensity * _flicker;
+        float halfWidth = 4f * Intensity * _flicker;
+
+        // Outer flame (orange)
+        _outerPaint.Color = FlameColor.WithAlpha(alpha);
+        using var outerPath = new SKPath();
+        outerPath.MoveTo(-halfWidth, 0);
+        outerPath.LineTo(halfWidth, 0);
+        outerPath.LineTo(0, length);
+        outerPath.Close();
+        canvas.DrawPath(outerPath, _outerPaint);
+
+        // Inner flame (yellow, smaller)
+        float innerHalfW = halfWidth * 0.5f;
+        float innerLen = length * 0.6f;
+        _innerPaint.Color = FlameInnerColor.WithAlpha(alpha);
+        using var innerPath = new SKPath();
+        innerPath.MoveTo(-innerHalfW, 0);
+        innerPath.LineTo(innerHalfW, 0);
+        innerPath.LineTo(0, innerLen);
+        innerPath.Close();
+        canvas.DrawPath(innerPath, _innerPaint);
+    }
+}

--- a/src/LunarLander/GameOverScreen.cs
+++ b/src/LunarLander/GameOverScreen.cs
@@ -1,0 +1,43 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.LunarLander.LunarLanderConstants;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>
+/// Game-over overlay drawn on top of the frozen play screen.
+/// Shows "LANDED SAFELY!" or "CRASHED!" based on the game state.
+/// </summary>
+internal sealed class GameOverScreen(LunarLanderGameState state, IScreenCoordinator coordinator) : GameScreen
+{
+    private static readonly SKPaint _overlayPaint = new() { Color = SKColors.Black.WithAlpha(186) };
+
+    private readonly TextSprite _titleText = new() { Size = 56f, Align = TextAlign.Center };
+    private readonly TextSprite _detailText = new() { Size = 24f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _promptText = new() { Text = "Click or Tap to Play Again", Size = 24f, Color = AccentColor, Align = TextAlign.Center };
+
+    public override void Draw(SKCanvas canvas, int width, int height)
+    {
+        canvas.DrawRect(0, 0, GameWidth, GameHeight, _overlayPaint);
+
+        if (state.Landed)
+        {
+            _titleText.Text = "LANDED SAFELY!";
+            _titleText.Color = SuccessColor;
+            _detailText.Text = $"Fuel remaining: {state.Fuel:F0}";
+        }
+        else
+        {
+            _titleText.Text = "CRASHED!";
+            _titleText.Color = DangerColor;
+            _detailText.Text = "Too fast or wrong angle!";
+        }
+
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 260f); _titleText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 310f); _detailText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 380f); _promptText.Draw(canvas); canvas.Restore();
+    }
+
+    public override void OnPointerDown(float x, float y)
+        => coordinator.TransitionTo<StartScreen>(new DissolveTransition());
+}

--- a/src/LunarLander/Lander.cs
+++ b/src/LunarLander/Lander.cs
@@ -1,0 +1,53 @@
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.LunarLander.LunarLanderConstants;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>
+/// The player's lander entity. Demonstrates rotation and child entities:
+/// flame sprites are children that rotate with the lander automatically.
+/// </summary>
+internal sealed class Lander : Entity
+{
+    public Lander()
+    {
+        Collider = new RectCollider { Width = LanderWidth, Height = LanderHeight };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new LanderSprite();
+
+        // Child entities for thruster flames — they orbit with lander rotation!
+        MainFlame = new Entity
+        {
+            Y = LanderHeight / 2f + 2f,
+            Sprite = new FlameSprite(),
+            Visible = false
+        };
+        LeftFlame = new Entity
+        {
+            X = -LanderWidth / 2f,
+            Y = -4f,
+            Rotation = 0.5f,
+            Sprite = new FlameSprite { Intensity = 0.5f },
+            Visible = false
+        };
+        RightFlame = new Entity
+        {
+            X = LanderWidth / 2f,
+            Y = -4f,
+            Rotation = -0.5f,
+            Sprite = new FlameSprite { Intensity = 0.5f },
+            Visible = false
+        };
+
+        AddChild(MainFlame);
+        AddChild(LeftFlame);
+        AddChild(RightFlame);
+    }
+
+    public Entity MainFlame { get; }
+    public Entity LeftFlame { get; }
+    public Entity RightFlame { get; }
+
+    public new LanderSprite Sprite { get => (LanderSprite)base.Sprite!; init => base.Sprite = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
+}

--- a/src/LunarLander/LanderSprite.cs
+++ b/src/LunarLander/LanderSprite.cs
@@ -1,0 +1,47 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.LunarLander.LunarLanderConstants;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>Draws a simple triangular lander hull centred at origin.</summary>
+internal sealed class LanderSprite : Sprite
+{
+    private readonly SKPaint _bodyPaint = new() { IsAntialias = true, Style = SKPaintStyle.Fill };
+    private readonly SKPaint _legPaint = new() { IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 2f };
+    private readonly SKPaint _windowPaint = new() { IsAntialias = true, Style = SKPaintStyle.Fill };
+
+    public SKColor Color { get; set; } = LanderColor;
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible || Alpha <= 0f)
+            return;
+
+        byte alpha = (byte)(255 * Alpha);
+        float halfW = LanderWidth / 2f;
+        float halfH = LanderHeight / 2f;
+
+        // Body — a trapezoid/triangle shape pointing up
+        _bodyPaint.Color = Color.WithAlpha(alpha);
+        using var bodyPath = new SKPath();
+        bodyPath.MoveTo(0, -halfH);                 // top (nose)
+        bodyPath.LineTo(halfW, halfH);               // bottom-right
+        bodyPath.LineTo(-halfW, halfH);              // bottom-left
+        bodyPath.Close();
+        canvas.DrawPath(bodyPath, _bodyPaint);
+
+        // Window — small circle near the top
+        _windowPaint.Color = AccentColor.WithAlpha(alpha);
+        canvas.DrawCircle(0, -halfH + 8f, 4f, _windowPaint);
+
+        // Landing legs
+        _legPaint.Color = Color.WithAlpha(alpha);
+        float legExtend = 6f;
+        canvas.DrawLine(-halfW, halfH, -halfW - 4f, halfH + legExtend, _legPaint);
+        canvas.DrawLine(halfW, halfH, halfW + 4f, halfH + legExtend, _legPaint);
+        // Horizontal foot pads
+        canvas.DrawLine(-halfW - 6f, halfH + legExtend, -halfW - 2f, halfH + legExtend, _legPaint);
+        canvas.DrawLine(halfW + 2f, halfH + legExtend, halfW + 6f, halfH + legExtend, _legPaint);
+    }
+}

--- a/src/LunarLander/LunarLanderConstants.cs
+++ b/src/LunarLander/LunarLanderConstants.cs
@@ -1,0 +1,53 @@
+using SkiaSharp;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>All layout, physics, and colour constants for the Lunar Lander game.</summary>
+internal static class LunarLanderConstants
+{
+    // ── Game dimensions ───────────────────────────────────────────────────
+    public const int GameWidth = 800;
+    public const int GameHeight = 600;
+
+    // ── Physics ───────────────────────────────────────────────────────────
+    public const float Gravity = 30f;           // px/s²
+    public const float ThrustForce = 70f;       // px/s² when thrusting
+    public const float RotationSpeed = 3f;      // rad/s
+
+    // ── Landing ───────────────────────────────────────────────────────────
+    public const float MaxLandingSpeed = 40f;   // safe landing threshold
+    public const float MaxLandingAngle = 0.3f;  // ~17°
+
+    // ── Lander ────────────────────────────────────────────────────────────
+    public const float LanderWidth = 30f;
+    public const float LanderHeight = 24f;
+
+    // ── Fuel ──────────────────────────────────────────────────────────────
+    public const float FuelMax = 100f;
+    public const float FuelBurnRate = 15f;      // units/s when thrusting
+
+    // ── Landing pad ───────────────────────────────────────────────────────
+    public const float LandingPadWidth = 80f;
+    public const float LandingPadHeight = 6f;
+
+    // ── Terrain ───────────────────────────────────────────────────────────
+    public const int TerrainSegments = 40;
+    public const float TerrainMinY = 400f;
+    public const float TerrainMaxY = 560f;
+
+    // ── Stars ─────────────────────────────────────────────────────────────
+    public const int StarCount = 80;
+
+    // ── Colours ───────────────────────────────────────────────────────────
+    public static readonly SKColor BackgroundColor = new(0x0A, 0x0A, 0x2A);
+    public static readonly SKColor PadColor = new(0x30, 0xD1, 0x58);
+    public static readonly SKColor LanderColor = SKColors.White;
+    public static readonly SKColor FlameColor = new(0xFF, 0x9F, 0x0A);
+    public static readonly SKColor FlameInnerColor = new(0xFF, 0xD6, 0x0A);
+    public static readonly SKColor TerrainColor = new(0x55, 0x55, 0x66);
+    public static readonly SKColor HudColor = SKColors.White;
+    public static readonly SKColor DimColor = new(0xAA, 0xAA, 0xAA);
+    public static readonly SKColor AccentColor = new(0x00, 0xD4, 0xFF);
+    public static readonly SKColor DangerColor = new(0xFF, 0x2D, 0x55);
+    public static readonly SKColor SuccessColor = new(0x30, 0xD1, 0x58);
+}

--- a/src/LunarLander/LunarLanderGame.cs
+++ b/src/LunarLander/LunarLanderGame.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+using SkiaSharpGames.GameEngine;
+
+namespace SkiaSharpGames.LunarLander;
+
+public static class LunarLanderGame
+{
+    public static Game Create()
+    {
+        var builder = GameBuilder.CreateDefault();
+
+        builder.SetGameDimensions(LunarLanderConstants.GameWidth, LunarLanderConstants.GameHeight);
+        builder.Services.AddSingleton<LunarLanderGameState>();
+
+        builder.Screens
+               .Add<StartScreen>()
+               .Add<PlayScreen>()
+               .Add<GameOverScreen>();
+
+        builder.SetInitialScreen<StartScreen>();
+
+        return builder.Build();
+    }
+}

--- a/src/LunarLander/LunarLanderGameState.cs
+++ b/src/LunarLander/LunarLanderGameState.cs
@@ -1,0 +1,9 @@
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>Shared mutable state passed between the Lunar Lander screens.</summary>
+internal sealed class LunarLanderGameState
+{
+    public float Fuel { get; set; } = LunarLanderConstants.FuelMax;
+    public bool Landed { get; set; }
+    public bool Crashed { get; set; }
+}

--- a/src/LunarLander/PlayScreen.cs
+++ b/src/LunarLander/PlayScreen.cs
@@ -1,0 +1,253 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.LunarLander.LunarLanderConstants;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>
+/// Main gameplay screen. The lander entity uses child entities for thruster flames
+/// that rotate automatically with the parent — demonstrating the Entity parenting system.
+/// </summary>
+internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator coordinator) : GameScreen
+{
+    // ── Entities ──────────────────────────────────────────────────────────
+    private readonly Lander _lander = new();
+    private readonly Terrain _terrain = new();
+
+    // ── Input state ──────────────────────────────────────────────────────
+    private bool _thrustInput;
+    private bool _rotateLeftInput;
+    private bool _rotateRightInput;
+    private bool _touchThrust;
+
+    // ── Stars ─────────────────────────────────────────────────────────────
+    private readonly SKPoint[] _stars = new SKPoint[StarCount];
+    private readonly float[] _starBrightness = new float[StarCount];
+
+    // ── HUD text ──────────────────────────────────────────────────────────
+    private readonly TextSprite _fuelText = new() { Size = 18f, Color = HudColor };
+    private readonly TextSprite _speedText = new() { Size = 18f, Color = HudColor, Align = TextAlign.Right };
+    private readonly TextSprite _altText = new() { Size = 18f, Color = HudColor, Align = TextAlign.Center };
+
+    // ── Paints ────────────────────────────────────────────────────────────
+    private readonly SKPaint _fuelBarBg = new() { Color = new SKColor(0x33, 0x33, 0x44), Style = SKPaintStyle.Fill };
+    private readonly SKPaint _fuelBarFg = new() { Style = SKPaintStyle.Fill };
+
+    private bool _gameOver;
+    private Random _rng = new();
+
+    public override void OnActivating()
+    {
+        _gameOver = false;
+        state.Fuel = FuelMax;
+        state.Landed = false;
+        state.Crashed = false;
+
+        _rng = new Random();
+
+        // Generate terrain
+        _terrain.Generate(_rng);
+
+        // Position lander at top-centre
+        _lander.X = GameWidth / 2f;
+        _lander.Y = 60f;
+        _lander.Rotation = 0f;
+        _lander.Rigidbody.SetVelocity(0, 0);
+        _lander.MainFlame.Visible = false;
+        _lander.LeftFlame.Visible = false;
+        _lander.RightFlame.Visible = false;
+
+        // Generate stars
+        for (int i = 0; i < StarCount; i++)
+        {
+            _stars[i] = new SKPoint(_rng.Next(0, GameWidth), _rng.Next(0, GameHeight));
+            _starBrightness[i] = 0.3f + (float)_rng.NextDouble() * 0.7f;
+        }
+    }
+
+    // ── Input ─────────────────────────────────────────────────────────────
+
+    public override void OnKeyDown(string key)
+    {
+        switch (key)
+        {
+            case "ArrowUp" or " ":
+                _thrustInput = true;
+                break;
+            case "ArrowLeft":
+                _rotateLeftInput = true;
+                break;
+            case "ArrowRight":
+                _rotateRightInput = true;
+                break;
+        }
+    }
+
+    public override void OnKeyUp(string key)
+    {
+        switch (key)
+        {
+            case "ArrowUp" or " ":
+                _thrustInput = false;
+                break;
+            case "ArrowLeft":
+                _rotateLeftInput = false;
+                break;
+            case "ArrowRight":
+                _rotateRightInput = false;
+                break;
+        }
+    }
+
+    public override void OnPointerDown(float x, float y)
+    {
+        _touchThrust = true;
+
+        // Touch on left/right side of screen for rotation
+        if (x < GameWidth * 0.33f)
+            _rotateLeftInput = true;
+        else if (x > GameWidth * 0.67f)
+            _rotateRightInput = true;
+    }
+
+    public override void OnPointerUp(float x, float y)
+    {
+        _touchThrust = false;
+        _rotateLeftInput = false;
+        _rotateRightInput = false;
+    }
+
+    // ── Update ────────────────────────────────────────────────────────────
+
+    public override void Update(float deltaTime)
+    {
+        if (_gameOver) return;
+
+        // Rotation
+        if (_rotateLeftInput)
+            _lander.Rotation -= RotationSpeed * deltaTime;
+        if (_rotateRightInput)
+            _lander.Rotation += RotationSpeed * deltaTime;
+
+        // Thrust
+        bool thrusting = (_thrustInput || _touchThrust) && state.Fuel > 0f;
+        if (thrusting)
+        {
+            float rot = _lander.Rotation;
+            float thrustX = -MathF.Sin(rot) * ThrustForce * deltaTime;
+            float thrustY = -MathF.Cos(rot) * ThrustForce * deltaTime;
+            _lander.Rigidbody.AddVelocity(thrustX, thrustY);
+            state.Fuel = MathF.Max(0f, state.Fuel - FuelBurnRate * deltaTime);
+        }
+
+        // Gravity
+        _lander.Rigidbody.AddVelocity(0, Gravity * deltaTime);
+
+        // Flame visibility — child entities rotate with the lander automatically!
+        _lander.MainFlame.Visible = thrusting;
+        _lander.LeftFlame.Visible = _rotateRightInput;
+        _lander.RightFlame.Visible = _rotateLeftInput;
+
+        // Update lander (rigidbody step + sprite + children)
+        _lander.Update(deltaTime);
+
+        // Landing / crash detection
+        CheckLanding();
+    }
+
+    private void CheckLanding()
+    {
+        float landerBottom = _lander.Y + LanderHeight / 2f + 6f; // include legs
+        float terrainY = _terrain.GetHeightAt(_lander.X);
+        bool overPad = _terrain.IsOverPad(_lander.X);
+        float padTop = _terrain.PadY - LandingPadHeight;
+
+        float contactY = overPad ? padTop : terrainY;
+
+        if (landerBottom < contactY)
+            return; // still in the air
+
+        float speed = _lander.Rigidbody.Speed;
+        float angle = MathF.Abs(NormalizeAngle(_lander.Rotation));
+
+        if (overPad && speed < MaxLandingSpeed && angle < MaxLandingAngle)
+        {
+            // Safe landing!
+            state.Landed = true;
+            _lander.Rigidbody.Stop();
+            _lander.Y = contactY - LanderHeight / 2f - 6f;
+            _lander.Rotation = 0f;
+        }
+        else
+        {
+            // Crash!
+            state.Crashed = true;
+            _lander.Rigidbody.Stop();
+        }
+
+        _lander.MainFlame.Visible = false;
+        _lander.LeftFlame.Visible = false;
+        _lander.RightFlame.Visible = false;
+        _gameOver = true;
+        coordinator.PushOverlay<GameOverScreen>();
+    }
+
+    private static float NormalizeAngle(float angle)
+    {
+        while (angle > MathF.PI) angle -= MathF.Tau;
+        while (angle < -MathF.PI) angle += MathF.Tau;
+        return angle;
+    }
+
+    // ── Draw ──────────────────────────────────────────────────────────────
+
+    public override void Draw(SKCanvas canvas, int width, int height)
+    {
+        canvas.Clear(BackgroundColor);
+        DrawGameContent(canvas);
+    }
+
+    internal void DrawGameContent(SKCanvas canvas)
+    {
+        // Stars
+        using var starPaint = new SKPaint { IsAntialias = true };
+        for (int i = 0; i < StarCount; i++)
+        {
+            byte a = (byte)(255 * _starBrightness[i]);
+            starPaint.Color = SKColors.White.WithAlpha(a);
+            canvas.DrawCircle(_stars[i].X, _stars[i].Y, 1.2f, starPaint);
+        }
+
+        // Terrain
+        _terrain.Draw(canvas);
+
+        // Lander — one call draws hull + all flame children automatically!
+        _lander.Draw(canvas);
+
+        // HUD
+        DrawHud(canvas);
+    }
+
+    private void DrawHud(SKCanvas canvas)
+    {
+        // Fuel bar
+        float barX = 20f, barY = 16f, barW = 120f, barH = 14f;
+        canvas.DrawRect(barX, barY, barW, barH, _fuelBarBg);
+        float fuelFrac = state.Fuel / FuelMax;
+        _fuelBarFg.Color = fuelFrac > 0.3f ? PadColor : DangerColor;
+        canvas.DrawRect(barX, barY, barW * fuelFrac, barH, _fuelBarFg);
+        _fuelText.Text = $"FUEL {state.Fuel:F0}";
+        canvas.Save(); canvas.Translate(barX, barY + barH + 16f); _fuelText.Draw(canvas); canvas.Restore();
+
+        // Speed
+        float speed = _lander.Rigidbody.Speed;
+        _speedText.Color = speed > MaxLandingSpeed ? DangerColor : HudColor;
+        _speedText.Text = $"SPD {speed:F0}";
+        canvas.Save(); canvas.Translate(GameWidth - 20f, 30f); _speedText.Draw(canvas); canvas.Restore();
+
+        // Altitude
+        float altitude = MathF.Max(0f, _terrain.GetHeightAt(_lander.X) - _lander.Y - LanderHeight / 2f);
+        _altText.Text = $"ALT {altitude:F0}";
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 30f); _altText.Draw(canvas); canvas.Restore();
+    }
+}

--- a/src/LunarLander/PlayScreen.cs
+++ b/src/LunarLander/PlayScreen.cs
@@ -285,9 +285,9 @@ internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator 
 
     private void DrawControlPad(SKCanvas canvas)
     {
-        DrawButton(canvas, LeftBtnRect, "◀", _touchLeft);
-        DrawButton(canvas, ThrustBtnRect, "▲", _touchThrust);
-        DrawButton(canvas, RightBtnRect, "▶", _touchRight);
+        DrawButton(canvas, LeftBtnRect, "<", _touchLeft);
+        DrawButton(canvas, ThrustBtnRect, "^", _touchThrust);
+        DrawButton(canvas, RightBtnRect, ">", _touchRight);
     }
 
     private static void DrawButton(SKCanvas canvas, SKRect rect, string label, bool pressed)

--- a/src/LunarLander/PlayScreen.cs
+++ b/src/LunarLander/PlayScreen.cs
@@ -18,7 +18,21 @@ internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator 
     private bool _thrustInput;
     private bool _rotateLeftInput;
     private bool _rotateRightInput;
-    private bool _touchThrust;
+
+    // ── Touch control pad ────────────────────────────────────────────────
+    private bool _touchActive;
+    private static readonly float PadY = GameHeight - 90f;
+    private static readonly float PadBtnW = 80f;
+    private static readonly float PadBtnH = 60f;
+    private static readonly float PadGap = 12f;
+    // Three buttons: [← rotate] [▲ thrust] [rotate →]
+    private static readonly float PadTotalW = PadBtnW * 3 + PadGap * 2;
+    private static readonly float PadLeft = (GameWidth - PadTotalW) / 2f;
+    private static readonly SKRect LeftBtnRect = SKRect.Create(PadLeft, PadY, PadBtnW, PadBtnH);
+    private static readonly SKRect ThrustBtnRect = SKRect.Create(PadLeft + PadBtnW + PadGap, PadY, PadBtnW, PadBtnH);
+    private static readonly SKRect RightBtnRect = SKRect.Create(PadLeft + 2 * (PadBtnW + PadGap), PadY, PadBtnW, PadBtnH);
+
+    private bool _touchLeft, _touchThrust, _touchRight;
 
     // ── Stars ─────────────────────────────────────────────────────────────
     private readonly SKPoint[] _stars = new SKPoint[StarCount];
@@ -99,22 +113,23 @@ internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator 
         }
     }
 
-    public override void OnPointerDown(float x, float y)
-    {
-        _touchThrust = true;
-
-        // Touch on left/right side of screen for rotation
-        if (x < GameWidth * 0.33f)
-            _rotateLeftInput = true;
-        else if (x > GameWidth * 0.67f)
-            _rotateRightInput = true;
-    }
+    public override void OnPointerDown(float x, float y) => HandleTouch(x, y, true);
+    public override void OnPointerMove(float x, float y) { if (_touchActive) HandleTouch(x, y, true); }
 
     public override void OnPointerUp(float x, float y)
     {
+        _touchActive = false;
+        _touchLeft = false;
         _touchThrust = false;
-        _rotateLeftInput = false;
-        _rotateRightInput = false;
+        _touchRight = false;
+    }
+
+    private void HandleTouch(float x, float y, bool down)
+    {
+        _touchActive = down;
+        _touchLeft = down && LeftBtnRect.Contains(x, y);
+        _touchThrust = down && ThrustBtnRect.Contains(x, y);
+        _touchRight = down && RightBtnRect.Contains(x, y);
     }
 
     // ── Update ────────────────────────────────────────────────────────────
@@ -123,18 +138,29 @@ internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator 
     {
         if (_gameOver) return;
 
-        // Rotation
-        if (_rotateLeftInput)
+        // Combine keyboard + touch inputs
+        bool wantLeft = _rotateLeftInput || _touchLeft;
+        bool wantRight = _rotateRightInput || _touchRight;
+        bool wantThrust = _thrustInput || _touchThrust;
+
+        // Rotation (consumes fuel via side thrusters)
+        if (wantLeft && state.Fuel > 0f)
+        {
             _lander.Rotation -= RotationSpeed * deltaTime;
-        if (_rotateRightInput)
+            state.Fuel = MathF.Max(0f, state.Fuel - FuelBurnRate * 0.3f * deltaTime);
+        }
+        if (wantRight && state.Fuel > 0f)
+        {
             _lander.Rotation += RotationSpeed * deltaTime;
+            state.Fuel = MathF.Max(0f, state.Fuel - FuelBurnRate * 0.3f * deltaTime);
+        }
 
         // Thrust
-        bool thrusting = (_thrustInput || _touchThrust) && state.Fuel > 0f;
+        bool thrusting = wantThrust && state.Fuel > 0f;
         if (thrusting)
         {
             float rot = _lander.Rotation;
-            float thrustX = -MathF.Sin(rot) * ThrustForce * deltaTime;
+            float thrustX = MathF.Sin(rot) * ThrustForce * deltaTime;
             float thrustY = -MathF.Cos(rot) * ThrustForce * deltaTime;
             _lander.Rigidbody.AddVelocity(thrustX, thrustY);
             state.Fuel = MathF.Max(0f, state.Fuel - FuelBurnRate * deltaTime);
@@ -144,9 +170,10 @@ internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator 
         _lander.Rigidbody.AddVelocity(0, Gravity * deltaTime);
 
         // Flame visibility — child entities rotate with the lander automatically!
+        bool hasFuel = state.Fuel > 0f;
         _lander.MainFlame.Visible = thrusting;
-        _lander.LeftFlame.Visible = _rotateRightInput;
-        _lander.RightFlame.Visible = _rotateLeftInput;
+        _lander.LeftFlame.Visible = wantRight && hasFuel;
+        _lander.RightFlame.Visible = wantLeft && hasFuel;
 
         // Update lander (rigidbody step + sprite + children)
         _lander.Update(deltaTime);
@@ -226,6 +253,7 @@ internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator 
 
         // HUD
         DrawHud(canvas);
+        DrawControlPad(canvas);
     }
 
     private void DrawHud(SKCanvas canvas)
@@ -249,5 +277,28 @@ internal sealed class PlayScreen(LunarLanderGameState state, IScreenCoordinator 
         float altitude = MathF.Max(0f, _terrain.GetHeightAt(_lander.X) - _lander.Y - LanderHeight / 2f);
         _altText.Text = $"ALT {altitude:F0}";
         canvas.Save(); canvas.Translate(GameWidth / 2f, 30f); _altText.Draw(canvas); canvas.Restore();
+    }
+
+    private static readonly SKPaint _padBtnPaint = new() { IsAntialias = true };
+    private static readonly SKPaint _padBtnTextPaint = new() { IsAntialias = true, Color = SKColors.White };
+    private static readonly SKFont _padBtnFont = new(SKTypeface.Default, 22f);
+
+    private void DrawControlPad(SKCanvas canvas)
+    {
+        DrawButton(canvas, LeftBtnRect, "◀", _touchLeft);
+        DrawButton(canvas, ThrustBtnRect, "▲", _touchThrust);
+        DrawButton(canvas, RightBtnRect, "▶", _touchRight);
+    }
+
+    private static void DrawButton(SKCanvas canvas, SKRect rect, string label, bool pressed)
+    {
+        byte alpha = pressed ? (byte)120 : (byte)50;
+        _padBtnPaint.Color = SKColors.White.WithAlpha(alpha);
+        canvas.DrawRoundRect(new SKRoundRect(rect, 8f), _padBtnPaint);
+
+        float textW = _padBtnFont.MeasureText(label);
+        float textX = rect.MidX - textW / 2f;
+        float textY = rect.MidY + 7f;
+        canvas.DrawText(label, textX, textY, _padBtnFont, _padBtnTextPaint);
     }
 }

--- a/src/LunarLander/SkiaSharpGames.LunarLander.csproj
+++ b/src/LunarLander/SkiaSharpGames.LunarLander.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>SkiaSharpGames.LunarLander</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" />
+    <PackageReference Include="SkiaSharp" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GameEngine\SkiaSharpGames.GameEngine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/LunarLander/StartScreen.cs
+++ b/src/LunarLander/StartScreen.cs
@@ -10,7 +10,7 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
     private readonly TextSprite _title = new() { Text = "LUNAR LANDER", Size = 64f, Color = SKColors.White, Align = TextAlign.Center };
     private readonly TextSprite _subtitle = new() { Text = "Entity Rotation & Child Entities Demo", Size = 18f, Color = AccentColor, Align = TextAlign.Center };
     private readonly TextSprite _startPrompt = new() { Text = "Click or Tap to Start", Size = 28f, Color = AccentColor, Align = TextAlign.Center };
-    private readonly TextSprite _instructions1 = new() { Text = "← → rotate     ↑ / SPACE thrust", Size = 18f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _instructions1 = new() { Text = "LEFT RIGHT rotate    UP / SPACE thrust", Size = 18f, Color = DimColor, Align = TextAlign.Center };
     private readonly TextSprite _instructions2 = new() { Text = "Land gently on the green pad", Size = 18f, Color = DimColor, Align = TextAlign.Center };
 
     private readonly SKPoint[] _stars = new SKPoint[StarCount];

--- a/src/LunarLander/StartScreen.cs
+++ b/src/LunarLander/StartScreen.cs
@@ -1,0 +1,68 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.LunarLander.LunarLanderConstants;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>Title screen: game title, instructions, click to start.</summary>
+internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
+{
+    private readonly TextSprite _title = new() { Text = "LUNAR LANDER", Size = 64f, Color = SKColors.White, Align = TextAlign.Center };
+    private readonly TextSprite _subtitle = new() { Text = "Entity Rotation & Child Entities Demo", Size = 18f, Color = AccentColor, Align = TextAlign.Center };
+    private readonly TextSprite _startPrompt = new() { Text = "Click or Tap to Start", Size = 28f, Color = AccentColor, Align = TextAlign.Center };
+    private readonly TextSprite _instructions1 = new() { Text = "← → rotate     ↑ / SPACE thrust", Size = 18f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _instructions2 = new() { Text = "Land gently on the green pad", Size = 18f, Color = DimColor, Align = TextAlign.Center };
+
+    private readonly SKPoint[] _stars = new SKPoint[StarCount];
+    private readonly float[] _starBrightness = new float[StarCount];
+    private readonly Random _rng = new(42);
+
+    public override void OnActivating()
+    {
+        for (int i = 0; i < StarCount; i++)
+        {
+            _stars[i] = new SKPoint(
+                _rng.Next(0, GameWidth),
+                _rng.Next(0, GameHeight));
+            _starBrightness[i] = 0.3f + (float)_rng.NextDouble() * 0.7f;
+        }
+    }
+
+    public override void Draw(SKCanvas canvas, int width, int height)
+    {
+        canvas.Clear(BackgroundColor);
+
+        // Stars
+        using var starPaint = new SKPaint { IsAntialias = true };
+        for (int i = 0; i < StarCount; i++)
+        {
+            byte a = (byte)(255 * _starBrightness[i]);
+            starPaint.Color = SKColors.White.WithAlpha(a);
+            canvas.DrawCircle(_stars[i].X, _stars[i].Y, 1.2f, starPaint);
+        }
+
+        // Simple lander illustration
+        DrawLanderIcon(canvas, GameWidth / 2f, 200f);
+
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 300f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 335f); _subtitle.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 400f); _startPrompt.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 450f); _instructions1.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 478f); _instructions2.Draw(canvas); canvas.Restore();
+    }
+
+    private static void DrawLanderIcon(SKCanvas canvas, float cx, float cy)
+    {
+        using var paint = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill, Color = LanderColor };
+        using var path = new SKPath();
+        float s = 2.5f; // scale
+        path.MoveTo(cx, cy - 12f * s);
+        path.LineTo(cx + 15f * s, cy + 12f * s);
+        path.LineTo(cx - 15f * s, cy + 12f * s);
+        path.Close();
+        canvas.DrawPath(path, paint);
+    }
+
+    public override void OnPointerDown(float x, float y)
+        => coordinator.TransitionTo<PlayScreen>(new DissolveTransition());
+}

--- a/src/LunarLander/StartScreen.cs
+++ b/src/LunarLander/StartScreen.cs
@@ -65,4 +65,10 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
 
     public override void OnPointerDown(float x, float y)
         => coordinator.TransitionTo<PlayScreen>(new DissolveTransition());
+
+    public override void OnKeyDown(string key)
+    {
+        if (key is " " or "Enter")
+            coordinator.TransitionTo<PlayScreen>(new DissolveTransition());
+    }
 }

--- a/src/LunarLander/Terrain.cs
+++ b/src/LunarLander/Terrain.cs
@@ -1,0 +1,93 @@
+using SkiaSharp;
+using static SkiaSharpGames.LunarLander.LunarLanderConstants;
+
+namespace SkiaSharpGames.LunarLander;
+
+/// <summary>
+/// Procedurally generated terrain with one flat landing pad section.
+/// Stores terrain as a list of points from left to right.
+/// </summary>
+internal sealed class Terrain
+{
+    private readonly SKPaint _terrainPaint = new() { IsAntialias = true, Style = SKPaintStyle.Fill, Color = TerrainColor };
+    private readonly SKPaint _padPaint = new() { IsAntialias = true, Style = SKPaintStyle.Fill, Color = PadColor };
+
+    public List<SKPoint> Points { get; } = [];
+
+    /// <summary>X centre of the landing pad.</summary>
+    public float PadCenterX { get; private set; }
+
+    /// <summary>Y position (top) of the landing pad.</summary>
+    public float PadY { get; private set; }
+
+    public void Generate(Random rng)
+    {
+        Points.Clear();
+
+        float segWidth = (float)GameWidth / TerrainSegments;
+
+        // Choose a random segment index for the landing pad (avoid edges)
+        int padSegIndex = rng.Next(4, TerrainSegments - 4);
+        int padSegCount = (int)MathF.Ceiling(LandingPadWidth / segWidth);
+
+        for (int i = 0; i <= TerrainSegments; i++)
+        {
+            float x = i * segWidth;
+            float y;
+
+            if (i >= padSegIndex && i <= padSegIndex + padSegCount)
+            {
+                // Flat landing pad section
+                y = TerrainMinY + (TerrainMaxY - TerrainMinY) * 0.6f;
+            }
+            else
+            {
+                y = TerrainMinY + (float)rng.NextDouble() * (TerrainMaxY - TerrainMinY);
+            }
+
+            Points.Add(new SKPoint(x, y));
+        }
+
+        // Record pad position
+        float padStartX = padSegIndex * segWidth;
+        float padEndX = (padSegIndex + padSegCount) * segWidth;
+        PadCenterX = (padStartX + padEndX) / 2f;
+        PadY = Points[padSegIndex].Y;
+    }
+
+    /// <summary>Returns the terrain height (Y) at a given X position via linear interpolation.</summary>
+    public float GetHeightAt(float x)
+    {
+        if (Points.Count < 2) return GameHeight;
+
+        float segWidth = (float)GameWidth / TerrainSegments;
+        int idx = Math.Clamp((int)(x / segWidth), 0, Points.Count - 2);
+        float t = (x - Points[idx].X) / segWidth;
+        return Points[idx].Y + t * (Points[idx + 1].Y - Points[idx].Y);
+    }
+
+    /// <summary>Returns true if the given X is over the landing pad.</summary>
+    public bool IsOverPad(float x)
+    {
+        float halfPad = LandingPadWidth / 2f;
+        return x >= PadCenterX - halfPad && x <= PadCenterX + halfPad;
+    }
+
+    public void Draw(SKCanvas canvas)
+    {
+        if (Points.Count < 2) return;
+
+        // Draw filled terrain
+        using var terrainPath = new SKPath();
+        terrainPath.MoveTo(0, GameHeight);
+        foreach (var pt in Points)
+            terrainPath.LineTo(pt.X, pt.Y);
+        terrainPath.LineTo(GameWidth, GameHeight);
+        terrainPath.Close();
+        canvas.DrawPath(terrainPath, _terrainPaint);
+
+        // Draw landing pad on top
+        float padLeft = PadCenterX - LandingPadWidth / 2f;
+        canvas.DrawRect(padLeft, PadY - LandingPadHeight, LandingPadWidth, LandingPadHeight, _padPaint);
+    }
+}

--- a/src/Pong/BallSprite.cs
+++ b/src/Pong/BallSprite.cs
@@ -13,7 +13,7 @@ internal sealed class BallSprite : Sprite
     public SKColor GlowColor { get; set; } = SKColors.White;
     public float GlowRadius { get; set; } = 2f;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
@@ -23,10 +23,10 @@ internal sealed class BallSprite : Sprite
         if (GlowRadius > 0f)
         {
             _glowPaint.Color = GlowColor.WithAlpha((byte)(a * 0.5f));
-            canvas.DrawCircle(x, y, Radius + GlowRadius, _glowPaint);
+            canvas.DrawCircle(0f, 0f, Radius + GlowRadius, _glowPaint);
         }
 
         _paint.Color = Color.WithAlpha(a);
-        canvas.DrawCircle(x, y, Radius, _paint);
+        canvas.DrawCircle(0f, 0f, Radius, _paint);
     }
 }

--- a/src/Pong/GameOverScreen.cs
+++ b/src/Pong/GameOverScreen.cs
@@ -18,12 +18,12 @@ internal sealed class GameOverScreen(PongGameState state, IScreenCoordinator coo
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), _overlayPaint);
 
         _winnerText.Text = state.WinnerText;
-        _winnerText.Draw(canvas, GameWidth / 2f, 260f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 260f); _winnerText.Draw(canvas); canvas.Restore();
 
         _scoreText.Text = $"{state.LeftScore} : {state.RightScore}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 325f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 325f); _scoreText.Draw(canvas); canvas.Restore();
 
-        _restartText.Draw(canvas, GameWidth / 2f, 395f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 395f); _restartText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/Pong/PaddleSprite.cs
+++ b/src/Pong/PaddleSprite.cs
@@ -12,13 +12,13 @@ internal sealed class PaddleSprite : Sprite
     public SKColor Color { get; set; }
     public float CornerRadius { get; set; } = 5f;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
-        var rect = SKRect.Create(x - Width / 2f, y - Height / 2f, Width, Height);
+        var rect = SKRect.Create(-Width / 2f, -Height / 2f, Width, Height);
         canvas.DrawRoundRect(rect, CornerRadius, CornerRadius, _paint);
     }
 }

--- a/src/Pong/PlayScreen.cs
+++ b/src/Pong/PlayScreen.cs
@@ -23,7 +23,7 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
     private readonly TextSprite _leftScoreText = new() { Size = 64f, Align = TextAlign.Center };
     private readonly TextSprite _rightScoreText = new() { Size = 64f, Align = TextAlign.Center };
     private readonly TextSprite _leftControlsText = new() { Text = "W / S", Size = 18f, Color = LeftPaddleColor };
-    private readonly TextSprite _rightControlsText = new() { Text = "\u2191 / \u2193", Size = 18f, Color = RightPaddleColor, Align = TextAlign.Right };
+    private readonly TextSprite _rightControlsText = new() { Text = "Up / Dn", Size = 18f, Color = RightPaddleColor, Align = TextAlign.Right };
     private readonly TextSprite _serveText = new() { Text = "Serve!", Size = 26f, Color = AccentColor, Align = TextAlign.Center };
 
     public override void OnActivated()

--- a/src/Pong/PlayScreen.cs
+++ b/src/Pong/PlayScreen.cs
@@ -17,11 +17,6 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
     private readonly PongEdge _rightGoalEdge = new(GameWidth + EdgeColliderThickness * 0.5f, GameHeight * 0.5f, EdgeColliderThickness, GameHeight);
     private int _serveDirection = 1;
 
-    private bool _leftUpHeld;
-    private bool _leftDownHeld;
-    private bool _rightUpHeld;
-    private bool _rightDownHeld;
-
     private CountdownTimer _serveTimer;
 
     // HUD text sprites
@@ -42,20 +37,21 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         _rightPaddle.X = GameWidth - PaddleMargin - PaddleWidth * 0.5f;
         _rightPaddle.Y = GameHeight * 0.5f;
 
-        _leftUpHeld = false;
-        _leftDownHeld = false;
-        _rightUpHeld = false;
-        _rightDownHeld = false;
+        _leftPaddle.UpHeld = false;
+        _leftPaddle.DownHeld = false;
+        _rightPaddle.UpHeld = false;
+        _rightPaddle.DownHeld = false;
 
         BeginServe(Random.Shared.Next(2) == 0 ? -1 : 1);
     }
 
     public override void OnPointerMove(float x, float y)
     {
+        float clamped = Math.Clamp(y, PaddleHeight * 0.5f, GameHeight - PaddleHeight * 0.5f);
         if (x < GameWidth * 0.5f)
-            _leftPaddle.Y = ClampPaddleY(y);
+            _leftPaddle.Y = clamped;
         else
-            _rightPaddle.Y = ClampPaddleY(y);
+            _rightPaddle.Y = clamped;
     }
 
     public override void OnKeyDown(string key)
@@ -64,17 +60,17 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         {
             case "w":
             case "W":
-                _leftUpHeld = true;
+                _leftPaddle.UpHeld = true;
                 break;
             case "s":
             case "S":
-                _leftDownHeld = true;
+                _leftPaddle.DownHeld = true;
                 break;
             case "ArrowUp":
-                _rightUpHeld = true;
+                _rightPaddle.UpHeld = true;
                 break;
             case "ArrowDown":
-                _rightDownHeld = true;
+                _rightPaddle.DownHeld = true;
                 break;
         }
     }
@@ -85,24 +81,25 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         {
             case "w":
             case "W":
-                _leftUpHeld = false;
+                _leftPaddle.UpHeld = false;
                 break;
             case "s":
             case "S":
-                _leftDownHeld = false;
+                _leftPaddle.DownHeld = false;
                 break;
             case "ArrowUp":
-                _rightUpHeld = false;
+                _rightPaddle.UpHeld = false;
                 break;
             case "ArrowDown":
-                _rightDownHeld = false;
+                _rightPaddle.DownHeld = false;
                 break;
         }
     }
 
     public override void Update(float deltaTime)
     {
-        UpdatePaddles(deltaTime);
+        _leftPaddle.Update(deltaTime);
+        _rightPaddle.Update(deltaTime);
 
         if (_serveTimer.Tick(deltaTime))
         {
@@ -115,7 +112,7 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         if (_serveTimer.Active)
             return;
 
-        _ball.Rigidbody.Step(_ball, deltaTime);
+        _ball.Update(deltaTime);
 
         ResolveEdgeCollision(_topEdge, _ball.Rigidbody.VelocityY < 0f);
         ResolveEdgeCollision(_bottomEdge, _ball.Rigidbody.VelocityY > 0f);
@@ -123,37 +120,21 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         ResolvePaddleCollision(isLeft: true);
         ResolvePaddleCollision(isLeft: false);
 
-        if (_ball.Rigidbody.VelocityX < 0f &&
-            CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _leftGoalEdge.X, _leftGoalEdge.Y, _leftGoalEdge.Collider, out _))
+        if (_ball.Rigidbody.VelocityX < 0f && _ball.TryGetHit(_leftGoalEdge, out _))
         {
             state.RightScore++;
             HandleScore(leftScored: false);
         }
-        else if (_ball.Rigidbody.VelocityX > 0f &&
-            CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _rightGoalEdge.X, _rightGoalEdge.Y, _rightGoalEdge.Collider, out _))
+        else if (_ball.Rigidbody.VelocityX > 0f && _ball.TryGetHit(_rightGoalEdge, out _))
         {
             state.LeftScore++;
             HandleScore(leftScored: true);
         }
     }
 
-    private void UpdatePaddles(float deltaTime)
-    {
-        float leftMove = 0f;
-        if (_leftUpHeld) leftMove -= PaddleSpeed * deltaTime;
-        if (_leftDownHeld) leftMove += PaddleSpeed * deltaTime;
-        _leftPaddle.Y = ClampPaddleY(_leftPaddle.Y + leftMove);
-
-        float rightMove = 0f;
-        if (_rightUpHeld) rightMove -= PaddleSpeed * deltaTime;
-        if (_rightDownHeld) rightMove += PaddleSpeed * deltaTime;
-        _rightPaddle.Y = ClampPaddleY(_rightPaddle.Y + rightMove);
-    }
-
     private void ResolveEdgeCollision(PongEdge edge, bool movingTowardEdge)
     {
-        if (!movingTowardEdge ||
-            !CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, edge.X, edge.Y, edge.Collider, out var hit))
+        if (!movingTowardEdge || !_ball.TryGetHit(edge, out var hit))
             return;
 
         _ball.X += hit.NormalX * hit.Penetration;
@@ -165,8 +146,7 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
     {
         var paddle = isLeft ? _leftPaddle : _rightPaddle;
         bool movingTowardPaddle = isLeft ? _ball.Rigidbody.VelocityX < 0f : _ball.Rigidbody.VelocityX > 0f;
-        if (!movingTowardPaddle ||
-            !CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, paddle.X, paddle.Y, paddle.Collider, out var hit))
+        if (!movingTowardPaddle || !_ball.TryGetHit(paddle, out var hit))
             return;
 
         _ball.X += hit.NormalX * hit.Penetration;
@@ -209,22 +189,19 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         _serveTimer.Set(ServeDelay);
     }
 
-    private static float ClampPaddleY(float y) =>
-        Math.Clamp(y, PaddleHeight * 0.5f, GameHeight - PaddleHeight * 0.5f);
-
     public override void Draw(SKCanvas canvas, int width, int height)
     {
         canvas.Clear(BackgroundColor);
 
-        canvas.Save(); canvas.Translate(_leftPaddle.X, _leftPaddle.Y); _leftPaddle.Sprite.Draw(canvas); canvas.Restore();
-        canvas.Save(); canvas.Translate(_rightPaddle.X, _rightPaddle.Y); _rightPaddle.Sprite.Draw(canvas); canvas.Restore();
+        _leftPaddle.Draw(canvas);
+        _rightPaddle.Draw(canvas);
 
         // Center-court dashed line
         _fillPaint.Color = SKColors.White.WithAlpha((byte)(255 * 0.5f));
         for (float y = 18f; y < GameHeight; y += 30f)
             canvas.DrawRect(SKRect.Create(GameWidth / 2f - 3f, y, 6f, 16f), _fillPaint);
 
-        canvas.Save(); canvas.Translate(_ball.X, _ball.Y); _ball.Sprite.Draw(canvas); canvas.Restore();
+        _ball.Draw(canvas);
 
         // Scores
         _leftScoreText.Text = state.LeftScore.ToString();

--- a/src/Pong/PlayScreen.cs
+++ b/src/Pong/PlayScreen.cs
@@ -124,13 +124,13 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         ResolvePaddleCollision(isLeft: false);
 
         if (_ball.Rigidbody.VelocityX < 0f &&
-            CollisionResolver.Overlaps(_ball, _ball.Collider, _leftGoalEdge, _leftGoalEdge.Collider))
+            CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _leftGoalEdge.X, _leftGoalEdge.Y, _leftGoalEdge.Collider, out _))
         {
             state.RightScore++;
             HandleScore(leftScored: false);
         }
         else if (_ball.Rigidbody.VelocityX > 0f &&
-            CollisionResolver.Overlaps(_ball, _ball.Collider, _rightGoalEdge, _rightGoalEdge.Collider))
+            CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, _rightGoalEdge.X, _rightGoalEdge.Y, _rightGoalEdge.Collider, out _))
         {
             state.LeftScore++;
             HandleScore(leftScored: true);
@@ -153,7 +153,7 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
     private void ResolveEdgeCollision(PongEdge edge, bool movingTowardEdge)
     {
         if (!movingTowardEdge ||
-            !CollisionResolver.TryGetHit(_ball, _ball.Collider, edge, edge.Collider, out var hit))
+            !CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, edge.X, edge.Y, edge.Collider, out var hit))
             return;
 
         _ball.X += hit.NormalX * hit.Penetration;
@@ -166,7 +166,7 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
         var paddle = isLeft ? _leftPaddle : _rightPaddle;
         bool movingTowardPaddle = isLeft ? _ball.Rigidbody.VelocityX < 0f : _ball.Rigidbody.VelocityX > 0f;
         if (!movingTowardPaddle ||
-            !CollisionResolver.TryGetHit(_ball, _ball.Collider, paddle, paddle.Collider, out var hit))
+            !CollisionResolver.TryGetHit(_ball.X, _ball.Y, _ball.Collider, paddle.X, paddle.Y, paddle.Collider, out var hit))
             return;
 
         _ball.X += hit.NormalX * hit.Penetration;
@@ -216,27 +216,29 @@ internal sealed class PlayScreen(PongGameState state, IScreenCoordinator coordin
     {
         canvas.Clear(BackgroundColor);
 
-        _leftPaddle.Sprite.Draw(canvas, _leftPaddle.X, _leftPaddle.Y);
-        _rightPaddle.Sprite.Draw(canvas, _rightPaddle.X, _rightPaddle.Y);
+        canvas.Save(); canvas.Translate(_leftPaddle.X, _leftPaddle.Y); _leftPaddle.Sprite.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(_rightPaddle.X, _rightPaddle.Y); _rightPaddle.Sprite.Draw(canvas); canvas.Restore();
 
         // Center-court dashed line
         _fillPaint.Color = SKColors.White.WithAlpha((byte)(255 * 0.5f));
         for (float y = 18f; y < GameHeight; y += 30f)
             canvas.DrawRect(SKRect.Create(GameWidth / 2f - 3f, y, 6f, 16f), _fillPaint);
 
-        _ball.Sprite.Draw(canvas, _ball.X, _ball.Y);
+        canvas.Save(); canvas.Translate(_ball.X, _ball.Y); _ball.Sprite.Draw(canvas); canvas.Restore();
 
         // Scores
         _leftScoreText.Text = state.LeftScore.ToString();
-        _leftScoreText.Draw(canvas, GameWidth * 0.34f, 82f);
+        canvas.Save(); canvas.Translate(GameWidth * 0.34f, 82f); _leftScoreText.Draw(canvas); canvas.Restore();
         _rightScoreText.Text = state.RightScore.ToString();
-        _rightScoreText.Draw(canvas, GameWidth * 0.66f, 82f);
+        canvas.Save(); canvas.Translate(GameWidth * 0.66f, 82f); _rightScoreText.Draw(canvas); canvas.Restore();
 
         // Control hints
-        _leftControlsText.Draw(canvas, 18f, 28f);
-        _rightControlsText.Draw(canvas, GameWidth - 18f, 28f);
+        canvas.Save(); canvas.Translate(18f, 28f); _leftControlsText.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth - 18f, 28f); _rightControlsText.Draw(canvas); canvas.Restore();
 
         if (_serveTimer.Active)
-            _serveText.Draw(canvas, GameWidth / 2f, 320f);
+        {
+            canvas.Save(); canvas.Translate(GameWidth / 2f, 320f); _serveText.Draw(canvas); canvas.Restore();
+        }
     }
 }

--- a/src/Pong/PongBall.cs
+++ b/src/Pong/PongBall.cs
@@ -6,13 +6,20 @@ namespace SkiaSharpGames.Pong;
 
 internal sealed class PongBall : Entity
 {
-    public readonly CircleCollider Collider = new() { Radius = BallRadius };
-    public readonly Rigidbody2D Rigidbody = new();
-    public readonly BallSprite Sprite = new()
+    public PongBall()
     {
-        Radius = BallRadius,
-        Color = SKColors.White,
-        GlowRadius = 2f,
-        GlowColor = SKColors.White,
-    };
+        Collider = new CircleCollider { Radius = BallRadius };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new BallSprite
+        {
+            Radius = BallRadius,
+            Color = SKColors.White,
+            GlowRadius = 2f,
+            GlowColor = SKColors.White,
+        };
+    }
+
+    public new BallSprite Sprite { get => (BallSprite)base.Sprite!; init => base.Sprite = value; }
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 }

--- a/src/Pong/PongEdge.cs
+++ b/src/Pong/PongEdge.cs
@@ -4,8 +4,6 @@ namespace SkiaSharpGames.Pong;
 
 internal sealed class PongEdge : Entity
 {
-    public readonly RectCollider Collider;
-
     public PongEdge(float x, float y, float width, float height)
     {
         X = x;

--- a/src/Pong/PongPaddle.cs
+++ b/src/Pong/PongPaddle.cs
@@ -4,19 +4,39 @@ using static SkiaSharpGames.Pong.PongConstants;
 
 namespace SkiaSharpGames.Pong;
 
-internal sealed class PongPaddle(SKColor color) : Entity
+internal sealed class PongPaddle : Entity
 {
-    public readonly RectCollider Collider = new()
+    public PongPaddle(SKColor color)
     {
-        Width = PaddleWidth,
-        Height = PaddleHeight,
-    };
+        Collider = new RectCollider
+        {
+            Width = PaddleWidth,
+            Height = PaddleHeight,
+        };
+        Sprite = new PaddleSprite
+        {
+            Width = PaddleWidth,
+            Height = PaddleHeight,
+            Color = color,
+            CornerRadius = 5f,
+        };
+    }
 
-    public readonly PaddleSprite Sprite = new()
+    public bool UpHeld { get; set; }
+    public bool DownHeld { get; set; }
+
+    public new PaddleSprite Sprite { get => (PaddleSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+
+    protected override void OnUpdate(float deltaTime)
     {
-        Width = PaddleWidth,
-        Height = PaddleHeight,
-        Color = color,
-        CornerRadius = 5f,
-    };
+        float move = 0f;
+        if (UpHeld) move -= PaddleSpeed * deltaTime;
+        if (DownHeld) move += PaddleSpeed * deltaTime;
+        if (move != 0f)
+            Y = ClampPaddleY(Y + move);
+    }
+
+    private static float ClampPaddleY(float y) =>
+        Math.Clamp(y, PaddleHeight * 0.5f, GameHeight - PaddleHeight * 0.5f);
 }

--- a/src/Pong/StartScreen.cs
+++ b/src/Pong/StartScreen.cs
@@ -8,7 +8,7 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
 {
     private readonly TextSprite _title = new() { Text = "2 PLAYER PONG", Size = 70f, Align = TextAlign.Center };
     private readonly TextSprite _leftControls = new() { Text = "Left: W / S", Size = 26f, Color = LeftPaddleColor, Align = TextAlign.Center };
-    private readonly TextSprite _rightControls = new() { Text = "Right: \u2191 / \u2193", Size = 26f, Color = RightPaddleColor, Align = TextAlign.Center };
+    private readonly TextSprite _rightControls = new() { Text = "Right: Up / Dn", Size = 26f, Color = RightPaddleColor, Align = TextAlign.Center };
     private readonly TextSprite _touchHint = new() { Text = "Touch or mouse: move the paddle on that side", Size = 20f, Color = DimColor, Align = TextAlign.Center };
     private readonly TextSprite _scoreHint = new() { Text = "First to 7 points wins", Size = 22f, Color = AccentColor, Align = TextAlign.Center };
     private readonly TextSprite _startPrompt = new() { Text = "Click, tap, or press Space to start", Size = 24f, Align = TextAlign.Center };

--- a/src/Pong/StartScreen.cs
+++ b/src/Pong/StartScreen.cs
@@ -17,12 +17,12 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
     {
         canvas.Clear(BackgroundColor);
 
-        _title.Draw(canvas, GameWidth / 2f, 235f);
-        _leftControls.Draw(canvas, GameWidth / 2f, 305f);
-        _rightControls.Draw(canvas, GameWidth / 2f, 340f);
-        _touchHint.Draw(canvas, GameWidth / 2f, 392f);
-        _scoreHint.Draw(canvas, GameWidth / 2f, 430f);
-        _startPrompt.Draw(canvas, GameWidth / 2f, 480f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 235f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 305f); _leftControls.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 340f); _rightControls.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 392f); _touchHint.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 430f); _scoreHint.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 480f); _startPrompt.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/SinkSub/DepthCharge.cs
+++ b/src/SinkSub/DepthCharge.cs
@@ -5,7 +5,14 @@ namespace SkiaSharpGames.SinkSub;
 
 internal sealed class DepthCharge : Entity
 {
-    public readonly CircleCollider Collider = new() { Radius = ChargeRadius };
-    public readonly Rigidbody2D Rigidbody = new();
-    public readonly DepthChargeSprite Sprite = new();
+    public DepthCharge()
+    {
+        Collider = new CircleCollider { Radius = ChargeRadius };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new DepthChargeSprite();
+    }
+
+    public new DepthChargeSprite Sprite { get => (DepthChargeSprite)base.Sprite!; init => base.Sprite = value; }
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 }

--- a/src/SinkSub/DepthChargeSprite.cs
+++ b/src/SinkSub/DepthChargeSprite.cs
@@ -18,7 +18,7 @@ internal sealed class DepthChargeSprite : Sprite
 
     public SKColor GlowColor { get; set; } = SKColors.White;
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
@@ -27,11 +27,11 @@ internal sealed class DepthChargeSprite : Sprite
         {
             EnsureGlowMask();
             _glowPaint.Color = GlowColor.WithAlpha((byte)(45 * Alpha));
-            canvas.DrawCircle(x, y, Radius + GlowRadius / 2f, _glowPaint);
+            canvas.DrawCircle(0f, 0f, Radius + GlowRadius / 2f, _glowPaint);
         }
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
-        canvas.DrawCircle(x, y, Radius, _paint);
+        canvas.DrawCircle(0f, 0f, Radius, _paint);
     }
 
     private void EnsureGlowMask()

--- a/src/SinkSub/GameOverScreen.cs
+++ b/src/SinkSub/GameOverScreen.cs
@@ -18,15 +18,15 @@ internal sealed class GameOverScreen(SinkSubGameState state, IScreenCoordinator 
         _fillPaint.Color = SKColors.Black.WithAlpha((byte)(255 * 0.78f));
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), _fillPaint);
 
-        _titleText.Draw(canvas, GameWidth / 2f, 250f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 250f); _titleText.Draw(canvas); canvas.Restore();
 
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 320f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 320f); _scoreText.Draw(canvas); canvas.Restore();
 
         _waveText.Text = $"Wave reached: {state.Wave}";
-        _waveText.Draw(canvas, GameWidth / 2f, 360f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 360f); _waveText.Draw(canvas); canvas.Restore();
 
-        _restartText.Draw(canvas, GameWidth / 2f, 420f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 420f); _restartText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/SinkSub/Mine.cs
+++ b/src/SinkSub/Mine.cs
@@ -5,7 +5,14 @@ namespace SkiaSharpGames.SinkSub;
 
 internal sealed class Mine : Entity
 {
-    public readonly CircleCollider Collider = new() { Radius = MineRadius };
-    public readonly Rigidbody2D Rigidbody = new();
-    public readonly MineSprite Sprite = new();
+    public Mine()
+    {
+        Collider = new CircleCollider { Radius = MineRadius };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new MineSprite();
+    }
+
+    public new MineSprite Sprite { get => (MineSprite)base.Sprite!; init => base.Sprite = value; }
+    public new CircleCollider Collider { get => (CircleCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 }

--- a/src/SinkSub/MineSprite.cs
+++ b/src/SinkSub/MineSprite.cs
@@ -18,7 +18,7 @@ internal sealed class MineSprite : Sprite
 
     public SKColor GlowColor { get; set; } = new SKColor(0xFF, 0xBF, 0x66);
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
@@ -27,11 +27,11 @@ internal sealed class MineSprite : Sprite
         {
             EnsureGlowMask();
             _glowPaint.Color = GlowColor.WithAlpha((byte)(55 * Alpha));
-            canvas.DrawCircle(x, y, Radius + GlowRadius / 2f, _glowPaint);
+            canvas.DrawCircle(0f, 0f, Radius + GlowRadius / 2f, _glowPaint);
         }
 
         _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
-        canvas.DrawCircle(x, y, Radius, _paint);
+        canvas.DrawCircle(0f, 0f, Radius, _paint);
     }
 
     private void EnsureGlowMask()

--- a/src/SinkSub/PlayScreen.cs
+++ b/src/SinkSub/PlayScreen.cs
@@ -147,7 +147,7 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
             {
                 var sub = _submarines[s];
                 if (!sub.Active ||
-                    !CollisionResolver.Overlaps(charge, charge.Collider, sub, sub.Collider))
+                    !CollisionResolver.TryGetHit(charge.X, charge.Y, charge.Collider, sub.X, sub.Y, sub.Collider, out _))
                     continue;
 
                 sub.Active = false;
@@ -202,7 +202,7 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
             var mine = _mines[i];
             mine.Rigidbody.Step(mine, deltaTime);
 
-            if (CollisionResolver.Overlaps(mine, mine.Collider, _ship, _ship.Collider))
+            if (CollisionResolver.TryGetHit(mine.X, mine.Y, mine.Collider, _ship.X, _ship.Y, _ship.Collider, out _))
             {
                 _mines.RemoveAt(i);
                 state.Lives--;
@@ -260,7 +260,9 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
         _ship.Draw(canvas);
 
         foreach (var charge in _charges)
-            charge.Sprite.Draw(canvas, charge.X, charge.Y);
+        {
+            canvas.Save(); canvas.Translate(charge.X, charge.Y); charge.Sprite.Draw(canvas); canvas.Restore();
+        }
 
         foreach (var sub in _submarines)
         {
@@ -269,26 +271,28 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
         }
 
         foreach (var mine in _mines)
-            mine.Sprite.Draw(canvas, mine.X, mine.Y);
+        {
+            canvas.Save(); canvas.Translate(mine.X, mine.Y); mine.Sprite.Draw(canvas); canvas.Restore();
+        }
 
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, 20f, 32f);
+        canvas.Save(); canvas.Translate(20f, 32f); _scoreText.Draw(canvas); canvas.Restore();
 
         _livesText.Text = $"Lives: {state.Lives}";
-        _livesText.Draw(canvas, 20f, 60f);
+        canvas.Save(); canvas.Translate(20f, 60f); _livesText.Draw(canvas); canvas.Restore();
 
         _waveText.Text = $"Wave: {state.Wave}";
-        _waveText.Draw(canvas, 20f, 88f);
+        canvas.Save(); canvas.Translate(20f, 88f); _waveText.Draw(canvas); canvas.Restore();
 
         _chargeText.Text = $"Charges: {_charges.Count}/{MaxCharges}";
-        _chargeText.Draw(canvas, GameWidth - 20f, 32f);
+        canvas.Save(); canvas.Translate(GameWidth - 20f, 32f); _chargeText.Draw(canvas); canvas.Restore();
 
-        _instructionsText.Draw(canvas, GameWidth / 2f, 32f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 32f); _instructionsText.Draw(canvas); canvas.Restore();
 
         if (_wavePending)
         {
             _waveIncomingText.Text = $"Wave {state.Wave + 1} incoming...";
-            _waveIncomingText.Draw(canvas, GameWidth / 2f, 170f);
+            canvas.Save(); canvas.Translate(GameWidth / 2f, 170f); _waveIncomingText.Draw(canvas); canvas.Restore();
         }
     }
 }

--- a/src/SinkSub/PlayScreen.cs
+++ b/src/SinkSub/PlayScreen.cs
@@ -16,9 +16,9 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
     private readonly TextSprite _waveIncomingText = new() { Size = 28f, Color = AccentColor, Align = TextAlign.Center };
 
     private readonly Ship _ship = new();
-    private readonly List<Submarine> _submarines = [];
-    private readonly List<DepthCharge> _charges = [];
-    private readonly List<Mine> _mines = [];
+    private readonly Entity _submarines = new();
+    private readonly Entity _depthCharges = new();
+    private readonly Entity _mines = new();
 
     private bool _leftHeld;
     private bool _rightHeld;
@@ -36,9 +36,9 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
         _rightHeld = false;
         _wavePending = false;
         _gameOverShown = false;
-        _charges.Clear();
-        _mines.Clear();
-        _submarines.Clear();
+        ClearChildren(_depthCharges);
+        ClearChildren(_mines);
+        ClearChildren(_submarines);
         _ship.X = GameWidth / 2f;
         _ship.Y = ShipY;
         StartNextWave();
@@ -98,7 +98,7 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
         UpdateSubmarines(deltaTime);
         UpdateMines(deltaTime);
 
-        if (!_wavePending && _submarines.All(s => !s.Active))
+        if (!_wavePending && _submarines.Children.All(s => !s.Active))
         {
             _wavePending = true;
             _nextWaveTimer.Set(1.2f);
@@ -123,7 +123,7 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
 
     private void DropCharge(bool leftSide)
     {
-        if (_charges.Count >= MaxCharges || _gameOverShown)
+        if (_depthCharges.ChildCount >= MaxCharges || _gameOverShown)
             return;
 
         var charge = new DepthCharge
@@ -132,44 +132,42 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
             Y = _ship.Y + ChargeSpawnOffsetY
         };
         charge.Rigidbody.SetVelocity(0f, ChargeSpeed);
-        _charges.Add(charge);
+        _depthCharges.AddChild(charge);
     }
 
     private void UpdateCharges(float deltaTime)
     {
-        for (int i = _charges.Count - 1; i >= 0; i--)
+        _depthCharges.Update(deltaTime);
+
+        var charges = _depthCharges.Children;
+        for (int i = charges.Count - 1; i >= 0; i--)
         {
-            var charge = _charges[i];
-            charge.Rigidbody.Step(charge, deltaTime);
+            var charge = (DepthCharge)charges[i];
+            if (!charge.Active) continue;
 
-            bool consumed = false;
-            for (int s = 0; s < _submarines.Count; s++)
+            if (_submarines.FindChildCollision(charge, out _) is Submarine sub)
             {
-                var sub = _submarines[s];
-                if (!sub.Active ||
-                    !CollisionResolver.TryGetHit(charge.X, charge.Y, charge.Collider, sub.X, sub.Y, sub.Collider, out _))
-                    continue;
-
                 sub.Active = false;
                 state.Score += 100;
-                _charges.RemoveAt(i);
-                consumed = true;
-                break;
+                charge.Active = false;
+                continue;
             }
 
-            if (!consumed && charge.Y > GameHeight + 20f)
-                _charges.RemoveAt(i);
+            if (charge.Y > GameHeight + 20f)
+                charge.Active = false;
         }
+
+        _depthCharges.RemoveInactiveChildren();
     }
 
     private void UpdateSubmarines(float deltaTime)
     {
-        foreach (var sub in _submarines)
-        {
-            if (!sub.Active)
-                continue;
+        _submarines.Update(deltaTime);
 
-            sub.Rigidbody.Step(sub, deltaTime);
+        foreach (var child in _submarines.Children)
+        {
+            if (child is not Submarine sub || !sub.Active)
+                continue;
 
             if (sub.X < SubWidth / 2f)
             {
@@ -182,7 +180,7 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
                 sub.Reverse();
             }
 
-            if (sub.TickMineTimer(deltaTime) && _mines.Count < 12)
+            if (sub.TickMineTimer(deltaTime) && _mines.ChildCount < 12)
             {
                 var mine = new Mine
                 {
@@ -190,21 +188,24 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
                     Y = sub.Y - 12f
                 };
                 mine.Rigidbody.SetVelocity(0f, -MineSpeed);
-                _mines.Add(mine);
+                _mines.AddChild(mine);
             }
         }
     }
 
     private void UpdateMines(float deltaTime)
     {
-        for (int i = _mines.Count - 1; i >= 0; i--)
-        {
-            var mine = _mines[i];
-            mine.Rigidbody.Step(mine, deltaTime);
+        _mines.Update(deltaTime);
 
-            if (CollisionResolver.TryGetHit(mine.X, mine.Y, mine.Collider, _ship.X, _ship.Y, _ship.Collider, out _))
+        var mines = _mines.Children;
+        for (int i = mines.Count - 1; i >= 0; i--)
+        {
+            var mine = (Mine)mines[i];
+            if (!mine.Active) continue;
+
+            if (mine.Overlaps(_ship))
             {
-                _mines.RemoveAt(i);
+                mine.Active = false;
                 state.Lives--;
 
                 if (state.Lives <= 0 && !_gameOverShown)
@@ -215,16 +216,18 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
             }
             else if (mine.Y < -20f)
             {
-                _mines.RemoveAt(i);
+                mine.Active = false;
             }
         }
+
+        _mines.RemoveInactiveChildren();
     }
 
     private void StartNextWave()
     {
         _wavePending = false;
         state.Wave++;
-        _submarines.Clear();
+        ClearChildren(_submarines);
 
         int subCount = Math.Min(2 + state.Wave, 5);
         for (int i = 0; i < subCount; i++)
@@ -238,7 +241,7 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
 
             var sub = new Submarine();
             sub.Reset(x, y, speed, direction, 1f + Random.Shared.NextSingle() * 2.4f);
-            _submarines.Add(sub);
+            _submarines.AddChild(sub);
         }
     }
 
@@ -258,22 +261,9 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
             canvas.DrawRect(SKRect.Create(30f + i * 110f, WaterlineY + 20f + (i % 2) * 10f, 60f, 2f), _fillPaint);
 
         _ship.Draw(canvas);
-
-        foreach (var charge in _charges)
-        {
-            canvas.Save(); canvas.Translate(charge.X, charge.Y); charge.Sprite.Draw(canvas); canvas.Restore();
-        }
-
-        foreach (var sub in _submarines)
-        {
-            if (sub.Active)
-                sub.Draw(canvas);
-        }
-
-        foreach (var mine in _mines)
-        {
-            canvas.Save(); canvas.Translate(mine.X, mine.Y); mine.Sprite.Draw(canvas); canvas.Restore();
-        }
+        _depthCharges.Draw(canvas);
+        _submarines.Draw(canvas);
+        _mines.Draw(canvas);
 
         _scoreText.Text = $"Score: {state.Score}";
         canvas.Save(); canvas.Translate(20f, 32f); _scoreText.Draw(canvas); canvas.Restore();
@@ -284,7 +274,7 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
         _waveText.Text = $"Wave: {state.Wave}";
         canvas.Save(); canvas.Translate(20f, 88f); _waveText.Draw(canvas); canvas.Restore();
 
-        _chargeText.Text = $"Charges: {_charges.Count}/{MaxCharges}";
+        _chargeText.Text = $"Charges: {_depthCharges.ChildCount}/{MaxCharges}";
         canvas.Save(); canvas.Translate(GameWidth - 20f, 32f); _chargeText.Draw(canvas); canvas.Restore();
 
         canvas.Save(); canvas.Translate(GameWidth / 2f, 32f); _instructionsText.Draw(canvas); canvas.Restore();
@@ -294,5 +284,11 @@ internal sealed class PlayScreen(SinkSubGameState state, IScreenCoordinator coor
             _waveIncomingText.Text = $"Wave {state.Wave + 1} incoming...";
             canvas.Save(); canvas.Translate(GameWidth / 2f, 170f); _waveIncomingText.Draw(canvas); canvas.Restore();
         }
+    }
+
+    private static void ClearChildren(Entity parent)
+    {
+        while (parent.ChildCount > 0)
+            parent.RemoveChild(parent.Children[^1]);
     }
 }

--- a/src/SinkSub/Ship.cs
+++ b/src/SinkSub/Ship.cs
@@ -1,4 +1,3 @@
-using SkiaSharp;
 using SkiaSharpGames.GameEngine;
 using static SkiaSharpGames.SinkSub.SinkSubConstants;
 
@@ -6,15 +5,12 @@ namespace SkiaSharpGames.SinkSub;
 
 internal sealed class Ship : Entity
 {
-    public readonly RectCollider Collider = new() { Width = ShipWidth, Height = ShipHeight };
-
-    public readonly ShipSprite Sprite = new();
-
-    public void Draw(SKCanvas canvas)
+    public Ship()
     {
-        canvas.Save();
-        canvas.Translate(X, Y);
-        Sprite.Draw(canvas);
-        canvas.Restore();
+        Collider = new RectCollider { Width = ShipWidth, Height = ShipHeight };
+        Sprite = new ShipSprite();
     }
+
+    public new ShipSprite Sprite { get => (ShipSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
 }

--- a/src/SinkSub/Ship.cs
+++ b/src/SinkSub/Ship.cs
@@ -10,5 +10,11 @@ internal sealed class Ship : Entity
 
     public readonly ShipSprite Sprite = new();
 
-    public void Draw(SKCanvas canvas) => Sprite.Draw(canvas, X, Y);
+    public void Draw(SKCanvas canvas)
+    {
+        canvas.Save();
+        canvas.Translate(X, Y);
+        Sprite.Draw(canvas);
+        canvas.Restore();
+    }
 }

--- a/src/SinkSub/ShipSprite.cs
+++ b/src/SinkSub/ShipSprite.cs
@@ -8,7 +8,7 @@ internal sealed class ShipSprite : Sprite
 {
     private readonly SKPaint _paint = new() { IsAntialias = true };
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
@@ -16,12 +16,12 @@ internal sealed class ShipSprite : Sprite
         byte a = (byte)(255 * Alpha);
 
         _paint.Color = new SKColor(0x4D, 0x5B, 0x6A).WithAlpha(a);
-        canvas.DrawRoundRect(SKRect.Create(x - ShipWidth / 2f, y - ShipHeight / 2f, ShipWidth, ShipHeight), 10f, 10f, _paint);
+        canvas.DrawRoundRect(SKRect.Create(0f - ShipWidth / 2f, 0f - ShipHeight / 2f, ShipWidth, ShipHeight), 10f, 10f, _paint);
 
         _paint.Color = new SKColor(0xD7, 0xDB, 0xE0).WithAlpha(a);
-        canvas.DrawRoundRect(SKRect.Create(x - 27f, y - 24f, 34f, 16f), 4f, 4f, _paint);
+        canvas.DrawRoundRect(SKRect.Create(0f - 27f, 0f - 24f, 34f, 16f), 4f, 4f, _paint);
 
         _paint.Color = SKColors.Black.WithAlpha(a);
-        canvas.DrawRect(SKRect.Create(x + 14f, y - 28f, 4f, 18f), _paint);
+        canvas.DrawRect(SKRect.Create(0f + 14f, 0f - 28f, 4f, 18f), _paint);
     }
 }

--- a/src/SinkSub/StartScreen.cs
+++ b/src/SinkSub/StartScreen.cs
@@ -24,12 +24,12 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
         _fillPaint.Color = DeepWaterColor.WithAlpha((byte)(255 * 0.6f));
         canvas.DrawRect(SKRect.Create(0f, WaterlineY + 180f, GameWidth, GameHeight - WaterlineY - 180f), _fillPaint);
 
-        _title.Draw(canvas, GameWidth / 2f, 215f);
-        _subtitle.Draw(canvas, GameWidth / 2f, 270f);
-        _instruction1.Draw(canvas, GameWidth / 2f, 345f);
-        _instruction2.Draw(canvas, GameWidth / 2f, 375f);
-        _instruction3.Draw(canvas, GameWidth / 2f, 405f);
-        _startPrompt.Draw(canvas, GameWidth / 2f, 465f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 215f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 270f); _subtitle.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 345f); _instruction1.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 375f); _instruction2.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 405f); _instruction3.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 465f); _startPrompt.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/SinkSub/Submarine.cs
+++ b/src/SinkSub/Submarine.cs
@@ -42,5 +42,11 @@ internal sealed class Submarine : Entity
         Rigidbody.SetVelocity(CruiseSpeed * Direction, 0f);
     }
 
-    public void Draw(SKCanvas canvas) => Sprite.Draw(canvas, X, Y);
+    public void Draw(SKCanvas canvas)
+    {
+        canvas.Save();
+        canvas.Translate(X, Y);
+        Sprite.Draw(canvas);
+        canvas.Restore();
+    }
 }

--- a/src/SinkSub/Submarine.cs
+++ b/src/SinkSub/Submarine.cs
@@ -1,4 +1,3 @@
-using SkiaSharp;
 using SkiaSharpGames.GameEngine;
 using static SkiaSharpGames.SinkSub.SinkSubConstants;
 
@@ -6,9 +5,16 @@ namespace SkiaSharpGames.SinkSub;
 
 internal sealed class Submarine : Entity
 {
-    public readonly RectCollider Collider = new() { Width = SubWidth, Height = SubHeight };
-    public readonly Rigidbody2D Rigidbody = new();
-    public readonly SubmarineSprite Sprite = new();
+    public Submarine()
+    {
+        Collider = new RectCollider { Width = SubWidth, Height = SubHeight };
+        Rigidbody = new Rigidbody2D();
+        Sprite = new SubmarineSprite();
+    }
+
+    public new SubmarineSprite Sprite { get => (SubmarineSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+    public new Rigidbody2D Rigidbody { get => (Rigidbody2D)base.Rigidbody!; init => base.Rigidbody = value; }
 
     public float CruiseSpeed { get; private set; }
 
@@ -40,13 +46,5 @@ internal sealed class Submarine : Entity
     {
         Direction = -Direction;
         Rigidbody.SetVelocity(CruiseSpeed * Direction, 0f);
-    }
-
-    public void Draw(SKCanvas canvas)
-    {
-        canvas.Save();
-        canvas.Translate(X, Y);
-        Sprite.Draw(canvas);
-        canvas.Restore();
     }
 }

--- a/src/SinkSub/SubmarineSprite.cs
+++ b/src/SinkSub/SubmarineSprite.cs
@@ -8,7 +8,7 @@ internal sealed class SubmarineSprite : Sprite
 {
     private readonly SKPaint _paint = new() { IsAntialias = true };
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         if (!Visible || Alpha <= 0f)
             return;
@@ -16,12 +16,12 @@ internal sealed class SubmarineSprite : Sprite
         byte a = (byte)(255 * Alpha);
 
         _paint.Color = new SKColor(0x3F, 0x6B, 0x7A).WithAlpha(a);
-        canvas.DrawRoundRect(SKRect.Create(x - SubWidth / 2f, y - SubHeight / 2f, SubWidth, SubHeight), 12f, 12f, _paint);
+        canvas.DrawRoundRect(SKRect.Create(0f - SubWidth / 2f, 0f - SubHeight / 2f, SubWidth, SubHeight), 12f, 12f, _paint);
 
         _paint.Color = new SKColor(0x2D, 0x4F, 0x5A).WithAlpha(a);
-        canvas.DrawRect(SKRect.Create(x - 10f, y - 18f, 20f, 8f), _paint);
+        canvas.DrawRect(SKRect.Create(0f - 10f, 0f - 18f, 20f, 8f), _paint);
 
         _paint.Color = SKColors.White.WithAlpha(110).WithAlpha(a);
-        canvas.DrawRect(SKRect.Create(x + 24f, y - 2f, 14f, 4f), _paint);
+        canvas.DrawRect(SKRect.Create(0f + 24f, 0f - 2f, 14f, 4f), _paint);
     }
 }

--- a/src/SpaceInvaders/Bullet.cs
+++ b/src/SpaceInvaders/Bullet.cs
@@ -1,21 +1,17 @@
-using SkiaSharp;
 using SkiaSharpGames.GameEngine;
 using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
 
 namespace SkiaSharpGames.SpaceInvaders;
 
-internal sealed class Bullet(bool fromEnemy) : Entity
+internal sealed class Bullet : Entity
 {
-    private static readonly SKPaint _playerBulletPaint = new() { Color = PlayerBulletColor, IsAntialias = true };
-    private static readonly SKPaint _enemyBulletPaint = new() { Color = EnemyBulletColor, IsAntialias = true };
+    public bool FromEnemy { get; }
 
-    public bool FromEnemy { get; } = fromEnemy;
-    public float SpeedY { get; set; }
-    public readonly RectCollider Collider = new() { Width = BulletWidth, Height = BulletHeight };
-
-    public void Draw(SKCanvas canvas)
+    public Bullet(bool fromEnemy, float speedY)
     {
-        var paint = FromEnemy ? _enemyBulletPaint : _playerBulletPaint;
-        canvas.DrawRect(X - BulletWidth / 2f, Y - BulletHeight / 2f, BulletWidth, BulletHeight, paint);
+        FromEnemy = fromEnemy;
+        Collider = new RectCollider { Width = BulletWidth, Height = BulletHeight };
+        Rigidbody = new Rigidbody2D { VelocityY = speedY };
+        Sprite = new BulletSprite { FromEnemy = fromEnemy };
     }
 }

--- a/src/SpaceInvaders/BulletSprite.cs
+++ b/src/SpaceInvaders/BulletSprite.cs
@@ -1,0 +1,19 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
+
+namespace SkiaSharpGames.SpaceInvaders;
+
+internal sealed class BulletSprite : Sprite
+{
+    private static readonly SKPaint _playerBulletPaint = new() { Color = PlayerBulletColor, IsAntialias = true };
+    private static readonly SKPaint _enemyBulletPaint = new() { Color = EnemyBulletColor, IsAntialias = true };
+
+    public bool FromEnemy { get; set; }
+
+    public override void Draw(SKCanvas canvas)
+    {
+        var paint = FromEnemy ? _enemyBulletPaint : _playerBulletPaint;
+        canvas.DrawRect(-BulletWidth / 2f, -BulletHeight / 2f, BulletWidth, BulletHeight, paint);
+    }
+}

--- a/src/SpaceInvaders/GameOverScreen.cs
+++ b/src/SpaceInvaders/GameOverScreen.cs
@@ -16,12 +16,12 @@ internal sealed class GameOverScreen(SpaceInvadersGameState state, IScreenCoordi
     {
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), _overlayPaint);
 
-        _titleText.Draw(canvas, GameWidth / 2f, 255f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 255f); _titleText.Draw(canvas); canvas.Restore();
 
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 325f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 325f); _scoreText.Draw(canvas); canvas.Restore();
 
-        _restartText.Draw(canvas, GameWidth / 2f, 410f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 410f); _restartText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/SpaceInvaders/Invader.cs
+++ b/src/SpaceInvaders/Invader.cs
@@ -1,17 +1,22 @@
-using SkiaSharp;
 using SkiaSharpGames.GameEngine;
 using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
 
 namespace SkiaSharpGames.SpaceInvaders;
 
-internal sealed class Invader(int row, int col) : Entity
+internal sealed class Invader : Entity
 {
-    private static readonly SKPaint _paint = new() { IsAntialias = true };
+    public int Row { get; }
+    public int Col { get; }
 
-    public int Row { get; } = row;
-    public int Col { get; } = col;
+    public Invader(int row, int col)
+    {
+        Row = row;
+        Col = col;
+        Collider = new RectCollider { Width = InvaderWidth, Height = InvaderHeight };
+        Sprite = new InvaderSprite { Row = row };
+    }
 
-    public readonly RectCollider Collider = new() { Width = InvaderWidth, Height = InvaderHeight };
+    public new InvaderSprite Sprite { get => (InvaderSprite)base.Sprite!; init => base.Sprite = value; }
 
     public int ScoreValue =>
         Row switch
@@ -20,35 +25,4 @@ internal sealed class Invader(int row, int col) : Entity
             1 or 2 => 20,
             _ => 10
         };
-
-    private SKColor Color =>
-        Row switch
-        {
-            0 => new SKColor(0xFF, 0x6B, 0x6B),
-            1 or 2 => new SKColor(0xFF, 0xD1, 0x66),
-            _ => new SKColor(0x6F, 0xD4, 0xFF)
-        };
-
-    public void Draw(SKCanvas canvas, bool frameB)
-    {
-        float left = X - InvaderWidth / 2f;
-        float top = Y - InvaderHeight / 2f;
-        float bodyH = InvaderHeight - 6f;
-
-        _paint.Color = Color;
-
-        canvas.DrawRect(left, top, InvaderWidth, bodyH, _paint);
-        canvas.DrawRect(left + 5f, top - 4f, InvaderWidth - 10f, 4f, _paint);
-
-        if (frameB)
-        {
-            canvas.DrawRect(left + 4f, top + bodyH, 5f, 6f, _paint);
-            canvas.DrawRect(left + InvaderWidth - 9f, top + bodyH, 5f, 6f, _paint);
-        }
-        else
-        {
-            canvas.DrawRect(left + 9f, top + bodyH, 5f, 6f, _paint);
-            canvas.DrawRect(left + InvaderWidth - 14f, top + bodyH, 5f, 6f, _paint);
-        }
-    }
 }

--- a/src/SpaceInvaders/InvaderSprite.cs
+++ b/src/SpaceInvaders/InvaderSprite.cs
@@ -1,0 +1,44 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
+
+namespace SkiaSharpGames.SpaceInvaders;
+
+internal sealed class InvaderSprite : Sprite
+{
+    private static readonly SKPaint _paint = new() { IsAntialias = true };
+
+    public bool FrameB { get; set; }
+    public int Row { get; set; }
+
+    private SKColor Color =>
+        Row switch
+        {
+            0 => new SKColor(0xFF, 0x6B, 0x6B),
+            1 or 2 => new SKColor(0xFF, 0xD1, 0x66),
+            _ => new SKColor(0x6F, 0xD4, 0xFF)
+        };
+
+    public override void Draw(SKCanvas canvas)
+    {
+        float left = -InvaderWidth / 2f;
+        float top = -InvaderHeight / 2f;
+        float bodyH = InvaderHeight - 6f;
+
+        _paint.Color = Color;
+
+        canvas.DrawRect(left, top, InvaderWidth, bodyH, _paint);
+        canvas.DrawRect(left + 5f, top - 4f, InvaderWidth - 10f, 4f, _paint);
+
+        if (FrameB)
+        {
+            canvas.DrawRect(left + 4f, top + bodyH, 5f, 6f, _paint);
+            canvas.DrawRect(left + InvaderWidth - 9f, top + bodyH, 5f, 6f, _paint);
+        }
+        else
+        {
+            canvas.DrawRect(left + 9f, top + bodyH, 5f, 6f, _paint);
+            canvas.DrawRect(left + InvaderWidth - 14f, top + bodyH, 5f, 6f, _paint);
+        }
+    }
+}

--- a/src/SpaceInvaders/PlayScreen.cs
+++ b/src/SpaceInvaders/PlayScreen.cs
@@ -481,9 +481,9 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
 
     private void DrawControlPad(SKCanvas canvas)
     {
-        DrawButton(canvas, LeftBtnRect, "◀", _touchLeft);
+        DrawButton(canvas, LeftBtnRect, "<", _touchLeft);
         DrawButton(canvas, FireBtnRect, "FIRE", _touchFire);
-        DrawButton(canvas, RightBtnRect, "▶", _touchRight);
+        DrawButton(canvas, RightBtnRect, ">", _touchRight);
     }
 
     private static void DrawButton(SKCanvas canvas, SKRect rect, string label, bool pressed)

--- a/src/SpaceInvaders/PlayScreen.cs
+++ b/src/SpaceInvaders/PlayScreen.cs
@@ -218,7 +218,7 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
             {
                 var invader = _invaders[invaderIndex];
                 if (!invader.Active ||
-                    !CollisionResolver.Overlaps(bullet, bullet.Collider, invader, invader.Collider))
+                    !CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, invader.X, invader.Y, invader.Collider, out _))
                     continue;
 
                 invader.Active = false;
@@ -235,7 +235,7 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
             {
                 var block = _shieldBlocks[shieldIndex];
                 if (!block.Active ||
-                    !CollisionResolver.Overlaps(bullet, bullet.Collider, block, block.Collider))
+                    !CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, block.X, block.Y, block.Collider, out _))
                     continue;
 
                 block.Hit();
@@ -250,7 +250,7 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
             for (int enemyIndex = _enemyBullets.Count - 1; enemyIndex >= 0; enemyIndex--)
             {
                 var enemyBullet = _enemyBullets[enemyIndex];
-                if (!CollisionResolver.Overlaps(bullet, bullet.Collider, enemyBullet, enemyBullet.Collider))
+                if (!CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, enemyBullet.X, enemyBullet.Y, enemyBullet.Collider, out _))
                     continue;
 
                 _enemyBullets.RemoveAt(enemyIndex);
@@ -273,7 +273,7 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
             {
                 var block = _shieldBlocks[shieldIndex];
                 if (!block.Active ||
-                    !CollisionResolver.Overlaps(bullet, bullet.Collider, block, block.Collider))
+                    !CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, block.X, block.Y, block.Collider, out _))
                     continue;
 
                 block.Hit();
@@ -285,7 +285,7 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
             if (consumed)
                 continue;
 
-            if (CollisionResolver.Overlaps(bullet, bullet.Collider, _player, _player.Collider))
+            if (CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, _player.X, _player.Y, _player.Collider, out _))
             {
                 _enemyBullets.RemoveAt(i);
                 state.Lives--;
@@ -404,12 +404,12 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         _player.Draw(canvas);
 
         _scoreText.Text = $"SCORE: {state.Score:0000}";
-        _scoreText.Draw(canvas, 20f, 34f);
+        canvas.Save(); canvas.Translate(20f, 34f); _scoreText.Draw(canvas); canvas.Restore();
 
         _livesText.Text = $"LIVES: {state.Lives}";
         float livesWidth = _livesText.MeasureWidth();
-        _livesText.Draw(canvas, GameWidth - livesWidth - 20f, 34f);
+        canvas.Save(); canvas.Translate(GameWidth - livesWidth - 20f, 34f); _livesText.Draw(canvas); canvas.Restore();
 
-        _controlsText.Draw(canvas, GameWidth / 2f, GameHeight - 12f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, GameHeight - 12f); _controlsText.Draw(canvas); canvas.Restore();
     }
 }

--- a/src/SpaceInvaders/PlayScreen.cs
+++ b/src/SpaceInvaders/PlayScreen.cs
@@ -10,7 +10,7 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
 
     private readonly TextSprite _scoreText = new() { Size = 24f, Color = SKColors.White };
     private readonly TextSprite _livesText = new() { Size = 24f, Color = AccentColor };
-    private readonly TextSprite _controlsText = new() { Text = "← → move    SPACE / ENTER fire", Size = 18f, Color = HudDimColor, Align = TextAlign.Center };
+    private readonly TextSprite _controlsText = new() { Text = "LEFT RIGHT move    SPACE / ENTER fire", Size = 18f, Color = HudDimColor, Align = TextAlign.Center };
 
     private readonly Entity _formation = new();
     private readonly Entity _shields = new();
@@ -18,6 +18,24 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
     private readonly Entity _enemyBullets = new();
     private readonly PlayerCannon _player = new();
     private readonly List<SKPoint> _stars = [];
+
+    // ── Touch control pad ────────────────────────────────────────────────
+    private bool _touchActive;
+    private bool _touchLeft, _touchRight, _touchFire;
+
+    private const float PadY = GameHeight - 80f;
+    private const float PadBtnW = 90f;
+    private const float PadBtnH = 50f;
+    private const float PadGap = 16f;
+    private static readonly float PadTotalW = PadBtnW * 3 + PadGap * 2;
+    private static readonly float PadLeft = (GameWidth - PadTotalW) / 2f;
+    private static readonly SKRect LeftBtnRect = SKRect.Create(PadLeft, PadY, PadBtnW, PadBtnH);
+    private static readonly SKRect FireBtnRect = SKRect.Create(PadLeft + PadBtnW + PadGap, PadY, PadBtnW, PadBtnH);
+    private static readonly SKRect RightBtnRect = SKRect.Create(PadLeft + 2 * (PadBtnW + PadGap), PadY, PadBtnW, PadBtnH);
+
+    private static readonly SKPaint _padBtnPaint = new() { IsAntialias = true };
+    private static readonly SKPaint _padBtnTextPaint = new() { IsAntialias = true, Color = SKColors.White };
+    private static readonly SKFont _padBtnFont = new(SKTypeface.Default, 22f);
 
     private bool _leftHeld;
     private bool _rightHeld;
@@ -41,6 +59,10 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         state.Lives = 3;
         _leftHeld = false;
         _rightHeld = false;
+        _touchActive = false;
+        _touchLeft = false;
+        _touchRight = false;
+        _touchFire = false;
         _invaderFrameB = false;
         _endTriggered = false;
         _invaderDirection = 1f;
@@ -58,12 +80,26 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         BuildShields();
     }
 
-    public override void OnPointerMove(float x, float y) => MovePlayerTo(x);
+    public override void OnPointerDown(float x, float y) => HandleTouch(x, y, true);
+    public override void OnPointerMove(float x, float y) { if (_touchActive) HandleTouch(x, y, true); }
 
-    public override void OnPointerDown(float x, float y)
+    public override void OnPointerUp(float x, float y)
     {
-        MovePlayerTo(x);
-        TryFirePlayerBullet();
+        _touchActive = false;
+        _touchLeft = false;
+        _touchRight = false;
+        _touchFire = false;
+    }
+
+    private void HandleTouch(float x, float y, bool down)
+    {
+        _touchActive = down;
+        _touchLeft = down && LeftBtnRect.Contains(x, y);
+        _touchRight = down && RightBtnRect.Contains(x, y);
+        bool wasFire = _touchFire;
+        _touchFire = down && FireBtnRect.Contains(x, y);
+        if (_touchFire && !wasFire)
+            TryFirePlayerBullet();
     }
 
     public override void OnKeyDown(string key)
@@ -101,9 +137,11 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         if (_endTriggered)
             return;
 
-        if (_leftHeld ^ _rightHeld)
+        bool moveLeft = _leftHeld || _touchLeft;
+        bool moveRight = _rightHeld || _touchRight;
+        if (moveLeft ^ moveRight)
         {
-            float direction = _leftHeld ? -1f : 1f;
+            float direction = moveLeft ? -1f : 1f;
             MovePlayerTo(_player.X + direction * PlayerSpeed * deltaTime);
         }
 
@@ -437,6 +475,27 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         canvas.Save(); canvas.Translate(GameWidth - livesWidth - 20f, 34f); _livesText.Draw(canvas); canvas.Restore();
 
         canvas.Save(); canvas.Translate(GameWidth / 2f, GameHeight - 12f); _controlsText.Draw(canvas); canvas.Restore();
+
+        DrawControlPad(canvas);
+    }
+
+    private void DrawControlPad(SKCanvas canvas)
+    {
+        DrawButton(canvas, LeftBtnRect, "◀", _touchLeft);
+        DrawButton(canvas, FireBtnRect, "FIRE", _touchFire);
+        DrawButton(canvas, RightBtnRect, "▶", _touchRight);
+    }
+
+    private static void DrawButton(SKCanvas canvas, SKRect rect, string label, bool pressed)
+    {
+        byte alpha = pressed ? (byte)120 : (byte)50;
+        _padBtnPaint.Color = SKColors.White.WithAlpha(alpha);
+        canvas.DrawRoundRect(new SKRoundRect(rect, 8f), _padBtnPaint);
+
+        float textW = _padBtnFont.MeasureText(label);
+        float textX = rect.MidX - textW / 2f;
+        float textY = rect.MidY + 7f;
+        canvas.DrawText(label, textX, textY, _padBtnFont, _padBtnTextPaint);
     }
 
     private static void ClearChildren(Entity parent)

--- a/src/SpaceInvaders/PlayScreen.cs
+++ b/src/SpaceInvaders/PlayScreen.cs
@@ -12,11 +12,11 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
     private readonly TextSprite _livesText = new() { Size = 24f, Color = AccentColor };
     private readonly TextSprite _controlsText = new() { Text = "← → move    SPACE / ENTER fire", Size = 18f, Color = HudDimColor, Align = TextAlign.Center };
 
+    private readonly Entity _formation = new();
+    private readonly Entity _shields = new();
+    private readonly Entity _playerBullets = new();
+    private readonly Entity _enemyBullets = new();
     private readonly PlayerCannon _player = new();
-    private readonly List<Invader> _invaders = [];
-    private readonly List<Bullet> _playerBullets = [];
-    private readonly List<Bullet> _enemyBullets = [];
-    private readonly List<ShieldBlock> _shieldBlocks = [];
     private readonly List<SKPoint> _stars = [];
 
     private bool _leftHeld;
@@ -47,10 +47,10 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         _playerFireCooldown = 0f;
         _invaderMoveTimer = InvaderMoveStartInterval;
         _enemyFireTimer = 0.8f;
-        _playerBullets.Clear();
-        _enemyBullets.Clear();
-        _invaders.Clear();
-        _shieldBlocks.Clear();
+        ClearChildren(_formation);
+        ClearChildren(_shields);
+        ClearChildren(_playerBullets);
+        ClearChildren(_enemyBullets);
 
         _player.X = GameWidth / 2f;
         _player.Y = PlayerY;
@@ -120,17 +120,17 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
 
     private void TryFirePlayerBullet()
     {
-        if (_playerFireCooldown > 0f || _playerBullets.Count > 0 || _endTriggered)
+        if (_playerFireCooldown > 0f || _playerBullets.ChildCount > 0 || _endTriggered)
             return;
 
         _playerFireCooldown = PlayerFireCooldown;
 
-        _playerBullets.Add(new Bullet(fromEnemy: false)
+        var bullet = new Bullet(fromEnemy: false, speedY: -PlayerBulletSpeed)
         {
             X = _player.X,
             Y = _player.Y - PlayerHeight / 2f - BulletHeight / 2f - 2f,
-            SpeedY = -PlayerBulletSpeed
-        });
+        };
+        _playerBullets.AddChild(bullet);
     }
 
     private void UpdateInvaderFormation(float deltaTime)
@@ -139,35 +139,49 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         if (_invaderMoveTimer > 0f)
             return;
 
-        int alive = _invaders.Count(i => i.Active);
+        var invaders = _formation.Children;
+        int alive = 0;
+        for (int i = 0; i < invaders.Count; i++)
+            if (invaders[i].Active) alive++;
+
         if (alive <= 0)
             return;
 
         float progress = 1f - alive / (float)(InvaderRows * InvaderCols);
         _invaderMoveTimer = InvaderMoveStartInterval + (InvaderMoveMinInterval - InvaderMoveStartInterval) * progress;
 
-        float minX = _invaders.Where(i => i.Active).Min(i => i.X);
-        float maxX = _invaders.Where(i => i.Active).Max(i => i.X);
+        float minX = float.MaxValue, maxX = float.MinValue;
+        for (int i = 0; i < invaders.Count; i++)
+        {
+            if (!invaders[i].Active) continue;
+            if (invaders[i].X < minX) minX = invaders[i].X;
+            if (invaders[i].X > maxX) maxX = invaders[i].X;
+        }
+
         float nextLeft = minX - InvaderWidth / 2f + InvaderStepX * _invaderDirection;
         float nextRight = maxX + InvaderWidth / 2f + InvaderStepX * _invaderDirection;
 
         bool hitSide = nextLeft <= InvaderSideMargin || nextRight >= GameWidth - InvaderSideMargin;
 
-        foreach (var invader in _invaders)
+        for (int i = 0; i < invaders.Count; i++)
         {
-            if (!invader.Active)
-                continue;
+            if (!invaders[i].Active) continue;
 
             if (hitSide)
-                invader.Y += InvaderStepDown;
+                invaders[i].Y += InvaderStepDown;
             else
-                invader.X += InvaderStepX * _invaderDirection;
+                invaders[i].X += InvaderStepX * _invaderDirection;
         }
 
         if (hitSide)
             _invaderDirection = -_invaderDirection;
 
         _invaderFrameB = !_invaderFrameB;
+        for (int i = 0; i < invaders.Count; i++)
+        {
+            if (invaders[i] is Invader inv)
+                inv.Sprite.FrameB = _invaderFrameB;
+        }
     }
 
     private void UpdateEnemyFire(float deltaTime)
@@ -176,7 +190,11 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         if (_enemyFireTimer > 0f)
             return;
 
-        int alive = _invaders.Count(i => i.Active);
+        var invaders = _formation.Children;
+        int alive = 0;
+        for (int i = 0; i < invaders.Count; i++)
+            if (invaders[i].Active) alive++;
+
         float threat = alive / (float)(InvaderRows * InvaderCols);
         float fireWindow = EnemyFireMinInterval + (EnemyFireMaxInterval - EnemyFireMinInterval) * threat;
         _enemyFireTimer = Random.Shared.NextSingle() * fireWindow + EnemyFireMinInterval;
@@ -185,120 +203,130 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         if (shooter is null)
             return;
 
-        _enemyBullets.Add(new Bullet(fromEnemy: true)
+        var bullet = new Bullet(fromEnemy: true, speedY: EnemyBulletSpeed)
         {
             X = shooter.X,
             Y = shooter.Y + InvaderHeight / 2f + BulletHeight / 2f + 2f,
-            SpeedY = EnemyBulletSpeed
-        });
+        };
+        _enemyBullets.AddChild(bullet);
     }
 
     private Invader? SelectEnemyShooter()
     {
-        List<int> columnsWithEnemies = [.. _invaders.Where(i => i.Active).Select(i => i.Col).Distinct()];
+        var invaders = _formation.Children;
+        List<int> columnsWithEnemies = [];
+        for (int i = 0; i < invaders.Count; i++)
+        {
+            if (invaders[i] is Invader inv && inv.Active && !columnsWithEnemies.Contains(inv.Col))
+                columnsWithEnemies.Add(inv.Col);
+        }
+
         if (columnsWithEnemies.Count == 0)
             return null;
 
         int column = columnsWithEnemies[Random.Shared.Next(columnsWithEnemies.Count)];
-        return _invaders
-            .Where(i => i.Active && i.Col == column)
-            .OrderByDescending(i => i.Row)
-            .FirstOrDefault();
+        Invader? best = null;
+        for (int i = 0; i < invaders.Count; i++)
+        {
+            if (invaders[i] is Invader inv && inv.Active && inv.Col == column)
+            {
+                if (best is null || inv.Row > best.Row)
+                    best = inv;
+            }
+        }
+
+        return best;
     }
 
     private void UpdateBullets(float deltaTime)
     {
-        for (int i = _playerBullets.Count - 1; i >= 0; i--)
+        // Update bullet positions via rigidbody
+        _playerBullets.Update(deltaTime);
+        _enemyBullets.Update(deltaTime);
+
+        // Player bullets vs invaders, shields, and enemy bullets
+        var playerBulletList = _playerBullets.Children;
+        for (int i = playerBulletList.Count - 1; i >= 0; i--)
         {
-            var bullet = _playerBullets[i];
-            bullet.Y += bullet.SpeedY * deltaTime;
+            var bullet = (Bullet)playerBulletList[i];
+            if (!bullet.Active) continue;
 
-            bool consumed = false;
-            for (int invaderIndex = 0; invaderIndex < _invaders.Count; invaderIndex++)
+            // vs invaders
+            var hitInvader = _formation.FindChildCollision(bullet, out _);
+            if (hitInvader is Invader invader)
             {
-                var invader = _invaders[invaderIndex];
-                if (!invader.Active ||
-                    !CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, invader.X, invader.Y, invader.Collider, out _))
-                    continue;
-
                 invader.Active = false;
                 state.Score += invader.ScoreValue;
-                _playerBullets.RemoveAt(i);
-                consumed = true;
-                break;
+                bullet.Active = false;
+                continue;
             }
 
-            if (consumed)
-                continue;
-
-            for (int shieldIndex = 0; shieldIndex < _shieldBlocks.Count; shieldIndex++)
+            // vs shields
+            var hitShield = _shields.FindChildCollision(bullet, out _);
+            if (hitShield is ShieldBlock block)
             {
-                var block = _shieldBlocks[shieldIndex];
-                if (!block.Active ||
-                    !CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, block.X, block.Y, block.Collider, out _))
-                    continue;
-
                 block.Hit();
-                _playerBullets.RemoveAt(i);
-                consumed = true;
-                break;
-            }
-
-            if (consumed)
+                bullet.Active = false;
                 continue;
-
-            for (int enemyIndex = _enemyBullets.Count - 1; enemyIndex >= 0; enemyIndex--)
-            {
-                var enemyBullet = _enemyBullets[enemyIndex];
-                if (!CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, enemyBullet.X, enemyBullet.Y, enemyBullet.Collider, out _))
-                    continue;
-
-                _enemyBullets.RemoveAt(enemyIndex);
-                _playerBullets.RemoveAt(i);
-                consumed = true;
-                break;
             }
 
-            if (!consumed && bullet.Y < -20f)
-                _playerBullets.RemoveAt(i);
+            // vs enemy bullets
+            var enemyBulletList = _enemyBullets.Children;
+            for (int j = enemyBulletList.Count - 1; j >= 0; j--)
+            {
+                var enemyBullet = enemyBulletList[j];
+                if (!enemyBullet.Active) continue;
+                if (bullet.Overlaps(enemyBullet))
+                {
+                    enemyBullet.Active = false;
+                    bullet.Active = false;
+                    break;
+                }
+            }
+
+            if (!bullet.Active) continue;
+
+            if (bullet.Y < -20f)
+                bullet.Active = false;
         }
 
-        for (int i = _enemyBullets.Count - 1; i >= 0; i--)
+        // Enemy bullets vs shields and player
+        var enemyBullets = _enemyBullets.Children;
+        for (int i = enemyBullets.Count - 1; i >= 0; i--)
         {
-            var bullet = _enemyBullets[i];
-            bullet.Y += bullet.SpeedY * deltaTime;
+            var bullet = (Bullet)enemyBullets[i];
+            if (!bullet.Active) continue;
 
-            bool consumed = false;
-            for (int shieldIndex = 0; shieldIndex < _shieldBlocks.Count; shieldIndex++)
+            // vs shields
+            var hitShield = _shields.FindChildCollision(bullet, out _);
+            if (hitShield is ShieldBlock block)
             {
-                var block = _shieldBlocks[shieldIndex];
-                if (!block.Active ||
-                    !CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, block.X, block.Y, block.Collider, out _))
-                    continue;
-
                 block.Hit();
-                _enemyBullets.RemoveAt(i);
-                consumed = true;
-                break;
+                bullet.Active = false;
+                continue;
             }
 
-            if (consumed)
-                continue;
-
-            if (CollisionResolver.TryGetHit(bullet.X, bullet.Y, bullet.Collider, _player.X, _player.Y, _player.Collider, out _))
+            // vs player
+            if (bullet.Overlaps(_player))
             {
-                _enemyBullets.RemoveAt(i);
+                bullet.Active = false;
                 state.Lives--;
-                _playerBullets.Clear();
+
+                // Clear all player bullets
+                for (int j = 0; j < playerBulletList.Count; j++)
+                    playerBulletList[j].Active = false;
 
                 if (state.Lives <= 0)
                     TriggerGameOver();
             }
             else if (bullet.Y > GameHeight + 20f)
             {
-                _enemyBullets.RemoveAt(i);
+                bullet.Active = false;
             }
         }
+
+        _playerBullets.RemoveInactiveChildren();
+        _enemyBullets.RemoveInactiveChildren();
     }
 
     private void CheckEndConditions()
@@ -306,13 +334,20 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         if (_endTriggered)
             return;
 
-        if (_invaders.Any(invader => invader.Active && invader.Y + InvaderHeight / 2f >= PlayerY - 24f))
+        var invaders = _formation.Children;
+        bool anyAlive = false;
+        for (int i = 0; i < invaders.Count; i++)
         {
-            TriggerGameOver();
-            return;
+            if (!invaders[i].Active) continue;
+            anyAlive = true;
+            if (invaders[i].Y + InvaderHeight / 2f >= PlayerY - 24f)
+            {
+                TriggerGameOver();
+                return;
+            }
         }
 
-        if (_invaders.All(invader => !invader.Active))
+        if (!anyAlive)
             TriggerVictory();
     }
 
@@ -343,11 +378,12 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         {
             for (int col = 0; col < InvaderCols; col++)
             {
-                _invaders.Add(new Invader(row, col)
+                var invader = new Invader(row, col)
                 {
                     X = startX + col * (InvaderWidth + InvaderSpacingX),
                     Y = InvaderStartY + row * (InvaderHeight + InvaderSpacingY),
-                });
+                };
+                _formation.AddChild(invader);
             }
         }
     }
@@ -369,11 +405,12 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
                     if (row == ShieldRows - 1 && col is 3 or 4)
                         continue;
 
-                    _shieldBlocks.Add(new ShieldBlock
+                    var block = new ShieldBlock
                     {
                         X = topLeftX + col * (ShieldBlockSize + ShieldBlockGap) + ShieldBlockSize / 2f,
                         Y = ShieldY + row * (ShieldBlockSize + ShieldBlockGap) + ShieldBlockSize / 2f
-                    });
+                    };
+                    _shields.AddChild(block);
                 }
             }
         }
@@ -386,21 +423,10 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         foreach (var star in _stars)
             canvas.DrawRect(star.X, star.Y, 2f, 2f, _starPaint);
 
-        foreach (var invader in _invaders)
-        {
-            if (invader.Active)
-                invader.Draw(canvas, _invaderFrameB);
-        }
-
-        foreach (var shield in _shieldBlocks)
-            shield.Draw(canvas);
-
-        foreach (var bullet in _playerBullets)
-            bullet.Draw(canvas);
-
-        foreach (var bullet in _enemyBullets)
-            bullet.Draw(canvas);
-
+        _formation.Draw(canvas);
+        _shields.Draw(canvas);
+        _playerBullets.Draw(canvas);
+        _enemyBullets.Draw(canvas);
         _player.Draw(canvas);
 
         _scoreText.Text = $"SCORE: {state.Score:0000}";
@@ -411,5 +437,11 @@ internal sealed class PlayScreen(SpaceInvadersGameState state, IScreenCoordinato
         canvas.Save(); canvas.Translate(GameWidth - livesWidth - 20f, 34f); _livesText.Draw(canvas); canvas.Restore();
 
         canvas.Save(); canvas.Translate(GameWidth / 2f, GameHeight - 12f); _controlsText.Draw(canvas); canvas.Restore();
+    }
+
+    private static void ClearChildren(Entity parent)
+    {
+        while (parent.ChildCount > 0)
+            parent.RemoveChild(parent.Children[^1]);
     }
 }

--- a/src/SpaceInvaders/PlayerCannon.cs
+++ b/src/SpaceInvaders/PlayerCannon.cs
@@ -1,4 +1,3 @@
-using SkiaSharp;
 using SkiaSharpGames.GameEngine;
 using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
 
@@ -6,14 +5,9 @@ namespace SkiaSharpGames.SpaceInvaders;
 
 internal sealed class PlayerCannon : Entity
 {
-    private static readonly SKPaint _paint = new() { Color = PlayerColor, IsAntialias = true };
-
-    public readonly RectCollider Collider = new() { Width = PlayerWidth, Height = PlayerHeight };
-
-    public void Draw(SKCanvas canvas)
+    public PlayerCannon()
     {
-        canvas.DrawRect(X - PlayerWidth / 2f, Y - PlayerHeight / 2f, PlayerWidth, PlayerHeight, _paint);
-        canvas.DrawRect(X - 9f, Y - PlayerHeight / 2f - 12f, 18f, 12f, _paint);
-        canvas.DrawRect(X - 2f, Y - PlayerHeight / 2f - 24f, 4f, 12f, _paint);
+        Collider = new RectCollider { Width = PlayerWidth, Height = PlayerHeight };
+        Sprite = new PlayerCannonSprite();
     }
 }

--- a/src/SpaceInvaders/PlayerCannonSprite.cs
+++ b/src/SpaceInvaders/PlayerCannonSprite.cs
@@ -1,0 +1,17 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
+
+namespace SkiaSharpGames.SpaceInvaders;
+
+internal sealed class PlayerCannonSprite : Sprite
+{
+    private static readonly SKPaint _paint = new() { Color = PlayerColor, IsAntialias = true };
+
+    public override void Draw(SKCanvas canvas)
+    {
+        canvas.DrawRect(-PlayerWidth / 2f, -PlayerHeight / 2f, PlayerWidth, PlayerHeight, _paint);
+        canvas.DrawRect(-9f, -PlayerHeight / 2f - 12f, 18f, 12f, _paint);
+        canvas.DrawRect(-2f, -PlayerHeight / 2f - 24f, 4f, 12f, _paint);
+    }
+}

--- a/src/SpaceInvaders/ShieldBlock.cs
+++ b/src/SpaceInvaders/ShieldBlock.cs
@@ -1,4 +1,3 @@
-using SkiaSharp;
 using SkiaSharpGames.GameEngine;
 using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
 
@@ -6,30 +5,21 @@ namespace SkiaSharpGames.SpaceInvaders;
 
 internal sealed class ShieldBlock : Entity
 {
-    private static readonly SKPaint _paint = new() { IsAntialias = true };
-
     public int HitPoints { get; private set; } = 3;
-    public readonly RectCollider Collider = new() { Width = ShieldBlockSize, Height = ShieldBlockSize };
+
+    public ShieldBlock()
+    {
+        Collider = new RectCollider { Width = ShieldBlockSize, Height = ShieldBlockSize };
+        Sprite = new ShieldBlockSprite();
+    }
+
+    public new ShieldBlockSprite Sprite { get => (ShieldBlockSprite)base.Sprite!; init => base.Sprite = value; }
 
     public void Hit()
     {
         HitPoints--;
+        Sprite.HitPoints = HitPoints;
         if (HitPoints <= 0)
             Active = false;
-    }
-
-    public void Draw(SKCanvas canvas)
-    {
-        if (!Active)
-            return;
-
-        _paint.Color = HitPoints switch
-        {
-            3 => new SKColor(0x48, 0xD0, 0x67),
-            2 => new SKColor(0x6B, 0xBA, 0x6A),
-            _ => new SKColor(0x88, 0x9A, 0x72)
-        };
-
-        canvas.DrawRect(X - ShieldBlockSize / 2f, Y - ShieldBlockSize / 2f, ShieldBlockSize, ShieldBlockSize, _paint);
     }
 }

--- a/src/SpaceInvaders/ShieldBlockSprite.cs
+++ b/src/SpaceInvaders/ShieldBlockSprite.cs
@@ -1,0 +1,24 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.SpaceInvaders.SpaceInvadersConstants;
+
+namespace SkiaSharpGames.SpaceInvaders;
+
+internal sealed class ShieldBlockSprite : Sprite
+{
+    private static readonly SKPaint _paint = new() { IsAntialias = true };
+
+    public int HitPoints { get; set; } = 3;
+
+    public override void Draw(SKCanvas canvas)
+    {
+        _paint.Color = HitPoints switch
+        {
+            3 => new SKColor(0x48, 0xD0, 0x67),
+            2 => new SKColor(0x6B, 0xBA, 0x6A),
+            _ => new SKColor(0x88, 0x9A, 0x72)
+        };
+
+        canvas.DrawRect(-ShieldBlockSize / 2f, -ShieldBlockSize / 2f, ShieldBlockSize, ShieldBlockSize, _paint);
+    }
+}

--- a/src/SpaceInvaders/StartScreen.cs
+++ b/src/SpaceInvaders/StartScreen.cs
@@ -17,12 +17,12 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
     {
         canvas.Clear(BackgroundColor);
 
-        _title.Draw(canvas, GameWidth / 2f, 215f);
-        _subtitle.Draw(canvas, GameWidth / 2f, 265f);
-        _moveHint.Draw(canvas, GameWidth / 2f, 340f);
-        _fireHint.Draw(canvas, GameWidth / 2f, 372f);
-        _goal.Draw(canvas, GameWidth / 2f, 430f);
-        _startPrompt.Draw(canvas, GameWidth / 2f, 485f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 215f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 265f); _subtitle.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 340f); _moveHint.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 372f); _fireHint.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 430f); _goal.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 485f); _startPrompt.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/SpaceInvaders/VictoryScreen.cs
+++ b/src/SpaceInvaders/VictoryScreen.cs
@@ -16,12 +16,12 @@ internal sealed class VictoryScreen(SpaceInvadersGameState state, IScreenCoordin
     {
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), _overlayPaint);
 
-        _titleText.Draw(canvas, GameWidth / 2f, 250f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 250f); _titleText.Draw(canvas); canvas.Restore();
 
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 320f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 320f); _scoreText.Draw(canvas); canvas.Restore();
 
-        _restartText.Draw(canvas, GameWidth / 2f, 410f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 410f); _restartText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/TwoZeroFourEight/GameOverScreen.cs
+++ b/src/TwoZeroFourEight/GameOverScreen.cs
@@ -17,15 +17,15 @@ internal sealed class GameOverScreen(TwoZeroFourEightGameState state, IScreenCoo
     {
         canvas.DrawRect(SKRect.Create(0, 0, GameWidth, GameHeight), _overlayPaint);
 
-        _titleText.Draw(canvas, GameWidth / 2f, 250f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 250f); _titleText.Draw(canvas); canvas.Restore();
 
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth / 2f, 320f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 320f); _scoreText.Draw(canvas); canvas.Restore();
 
         _bestText.Text = $"Best: {state.BestScore}";
-        _bestText.Draw(canvas, GameWidth / 2f, 360f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 360f); _bestText.Draw(canvas); canvas.Restore();
 
-        _restartText.Draw(canvas, GameWidth / 2f, 425f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 425f); _restartText.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/src/TwoZeroFourEight/PlayScreen.cs
+++ b/src/TwoZeroFourEight/PlayScreen.cs
@@ -140,15 +140,15 @@ internal sealed class PlayScreen(TwoZeroFourEightGameState state, IScreenCoordin
     {
         canvas.Clear(BackgroundColor);
 
-        _headerText.Draw(canvas, 90f, 94f);
+        canvas.Save(); canvas.Translate(90f, 94f); _headerText.Draw(canvas); canvas.Restore();
 
         _scoreText.Text = $"Score: {state.Score}";
-        _scoreText.Draw(canvas, GameWidth - 280f, 72f);
+        canvas.Save(); canvas.Translate(GameWidth - 280f, 72f); _scoreText.Draw(canvas); canvas.Restore();
 
         _bestText.Text = $"Best: {state.BestScore}";
-        _bestText.Draw(canvas, GameWidth - 280f, 102f);
+        canvas.Save(); canvas.Translate(GameWidth - 280f, 102f); _bestText.Draw(canvas); canvas.Restore();
 
-        _controlsText.Draw(canvas, GameWidth / 2f, 64f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 64f); _controlsText.Draw(canvas); canvas.Restore();
 
         var boardRect = SKRect.Create(BoardX, BoardY, BoardPixelSize, BoardPixelSize);
         canvas.DrawRoundRect(boardRect, 18f, 18f, _boardPaint);
@@ -178,7 +178,7 @@ internal sealed class PlayScreen(TwoZeroFourEightGameState state, IScreenCoordin
         _footerText.Text = state.HasReached2048
             ? "2048 reached! Keep going..."
             : "Merge tiles to reach 2048";
-        _footerText.Draw(canvas, GameWidth / 2f, 565f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 565f); _footerText.Draw(canvas); canvas.Restore();
     }
 
     private void DrawSlideTiles(SKCanvas canvas)
@@ -236,7 +236,7 @@ internal sealed class PlayScreen(TwoZeroFourEightGameState state, IScreenCoordin
         _tileText.Size = textSize;
         _tileText.Color = value <= 4 ? DarkTextColor : LightTextColor;
         _tileText.Align = TextAlign.Center;
-        _tileText.Draw(canvas, left + size / 2f, top + size / 2f + textSize / 3f);
+        canvas.Save(); canvas.Translate(left + size / 2f, top + size / 2f + textSize / 3f); _tileText.Draw(canvas); canvas.Restore();
     }
 
     private void TryMove(MoveDirection direction)

--- a/src/TwoZeroFourEight/StartScreen.cs
+++ b/src/TwoZeroFourEight/StartScreen.cs
@@ -15,10 +15,10 @@ internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
     {
         canvas.Clear(BackgroundColor);
 
-        _title.Draw(canvas, GameWidth / 2f, 180f);
-        _subtitle.Draw(canvas, GameWidth / 2f, 250f);
-        _controls.Draw(canvas, GameWidth / 2f, 320f);
-        _startPrompt.Draw(canvas, GameWidth / 2f, 360f);
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 180f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 250f); _subtitle.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 320f); _controls.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(GameWidth / 2f, 360f); _startPrompt.Draw(canvas); canvas.Restore();
     }
 
     public override void OnPointerDown(float x, float y) =>

--- a/tests/GameEngine.Tests/CollisionResolverTests.cs
+++ b/tests/GameEngine.Tests/CollisionResolverTests.cs
@@ -4,15 +4,13 @@ namespace SkiaSharpGames.GameEngine.Tests;
 
 public class CollisionResolverTests
 {
-    private sealed class TestEntity : Entity { }
-
     [Fact]
     public void CircleCollider_BoundingBox_CentredOnEntity()
     {
-        var entity = new TestEntity { X = 100f, Y = 200f };
+        var entity = new Entity { X = 100f, Y = 200f };
         var collider = new CircleCollider { Radius = 10f };
 
-        var bounds = collider.BoundingBox(entity);
+        var bounds = collider.BoundingBox(entity.X, entity.Y);
 
         Assert.Equal(90f, bounds.Left, precision: 4);
         Assert.Equal(190f, bounds.Top, precision: 4);
@@ -23,10 +21,10 @@ public class CollisionResolverTests
     [Fact]
     public void RectCollider_WorldRect_IsCentredOnEntity()
     {
-        var entity = new TestEntity { X = 50f, Y = 30f };
+        var entity = new Entity { X = 50f, Y = 30f };
         var collider = new RectCollider { Width = 20f, Height = 10f };
 
-        var bounds = collider.WorldRect(entity);
+        var bounds = collider.WorldRect(entity.X, entity.Y);
 
         Assert.Equal(40f, bounds.Left, precision: 4);
         Assert.Equal(25f, bounds.Top, precision: 4);
@@ -37,7 +35,7 @@ public class CollisionResolverTests
     [Fact]
     public void Rigidbody2D_Step_MovesEntity()
     {
-        var entity = new TestEntity { X = 10f, Y = 20f };
+        var entity = new Entity { X = 10f, Y = 20f };
         var body = new Rigidbody2D();
         body.SetVelocity(100f, -50f);
 
@@ -105,25 +103,21 @@ public class CollisionResolverTests
     [Fact]
     public void Overlaps_CircleCircle_WhenOverlapping_ReturnsTrue()
     {
-        var a = new TestEntity { X = 0f, Y = 0f };
-        var b = new TestEntity { X = 5f, Y = 0f };
-        var aCollider = new CircleCollider { Radius = 10f };
-        var bCollider = new CircleCollider { Radius = 10f };
+        var a = new Entity { X = 0f, Y = 0f, Collider = new CircleCollider { Radius = 10f } };
+        var b = new Entity { X = 5f, Y = 0f, Collider = new CircleCollider { Radius = 10f } };
 
-        Assert.True(CollisionResolver.Overlaps(a, aCollider, b, bCollider));
-        Assert.True(CollisionResolver.TryGetHit(a, aCollider, b, bCollider, out var hit));
+        Assert.True(CollisionResolver.Overlaps(a, b));
+        Assert.True(CollisionResolver.TryGetHit(a, b, out var hit));
         Assert.True(hit.NormalX < 0f);
     }
 
     [Fact]
     public void TryGetHit_CircleCircle_SamePosition_UsesFallbackNormal()
     {
-        var a = new TestEntity { X = 0f, Y = 0f };
-        var b = new TestEntity { X = 0f, Y = 0f };
-        var aCollider = new CircleCollider { Radius = 10f };
-        var bCollider = new CircleCollider { Radius = 10f };
+        var a = new Entity { X = 0f, Y = 0f, Collider = new CircleCollider { Radius = 10f } };
+        var b = new Entity { X = 0f, Y = 0f, Collider = new CircleCollider { Radius = 10f } };
 
-        var result = CollisionResolver.TryGetHit(a, aCollider, b, bCollider, out var hit);
+        var result = CollisionResolver.TryGetHit(a, b, out var hit);
 
         Assert.True(result);
         Assert.Equal(0f, hit.NormalX, precision: 4);
@@ -133,23 +127,19 @@ public class CollisionResolverTests
     [Fact]
     public void Overlaps_CircleRect_WhenCircleInsideRect_ReturnsTrue()
     {
-        var circleOwner = new TestEntity { X = 50f, Y = 50f };
-        var rectOwner = new TestEntity { X = 50f, Y = 50f };
-        var circle = new CircleCollider { Radius = 5f };
-        var rect = new RectCollider { Width = 100f, Height = 100f };
+        var circleOwner = new Entity { X = 50f, Y = 50f, Collider = new CircleCollider { Radius = 5f } };
+        var rectOwner = new Entity { X = 50f, Y = 50f, Collider = new RectCollider { Width = 100f, Height = 100f } };
 
-        Assert.True(CollisionResolver.Overlaps(circleOwner, circle, rectOwner, rect));
+        Assert.True(CollisionResolver.Overlaps(circleOwner, rectOwner));
     }
 
     [Fact]
     public void TryGetHit_CircleRect_FromTop_ReturnsUpwardNormal()
     {
-        var ball = new TestEntity { X = 50f, Y = 19f };
-        var brick = new TestEntity { X = 50f, Y = 31f };
-        var circle = new CircleCollider { Radius = 8f };
-        var rect = new RectCollider { Width = 100f, Height = 22f };
+        var ball = new Entity { X = 50f, Y = 19f, Collider = new CircleCollider { Radius = 8f } };
+        var brick = new Entity { X = 50f, Y = 31f, Collider = new RectCollider { Width = 100f, Height = 22f } };
 
-        var result = CollisionResolver.TryGetHit(ball, circle, brick, rect, out var hit);
+        var result = CollisionResolver.TryGetHit(ball, brick, out var hit);
 
         Assert.True(result);
         Assert.True(hit.IsVertical);
@@ -159,12 +149,10 @@ public class CollisionResolverTests
     [Fact]
     public void TryGetHit_CircleRect_FromSide_ReturnsHorizontalNormal()
     {
-        var ball = new TestEntity { X = 3f, Y = 50f };
-        var wall = new TestEntity { X = 50f, Y = 100f };
-        var circle = new CircleCollider { Radius = 8f };
-        var rect = new RectCollider { Width = 100f, Height = 200f };
+        var ball = new Entity { X = 3f, Y = 50f, Collider = new CircleCollider { Radius = 8f } };
+        var wall = new Entity { X = 50f, Y = 100f, Collider = new RectCollider { Width = 100f, Height = 200f } };
 
-        var result = CollisionResolver.TryGetHit(ball, circle, wall, rect, out var hit);
+        var result = CollisionResolver.TryGetHit(ball, wall, out var hit);
 
         Assert.True(result);
         Assert.True(hit.IsHorizontal);
@@ -174,12 +162,10 @@ public class CollisionResolverTests
     [Fact]
     public void TryGetHit_CircleRect_WhenSeparated_ReturnsFalse()
     {
-        var circleOwner = new TestEntity { X = 500f, Y = 500f };
-        var rectOwner = new TestEntity { X = 50f, Y = 50f };
-        var circle = new CircleCollider { Radius = 5f };
-        var rect = new RectCollider { Width = 100f, Height = 100f };
+        var circleOwner = new Entity { X = 500f, Y = 500f, Collider = new CircleCollider { Radius = 5f } };
+        var rectOwner = new Entity { X = 50f, Y = 50f, Collider = new RectCollider { Width = 100f, Height = 100f } };
 
-        var result = CollisionResolver.TryGetHit(circleOwner, circle, rectOwner, rect, out _);
+        var result = CollisionResolver.TryGetHit(circleOwner, rectOwner, out _);
 
         Assert.False(result);
     }
@@ -187,25 +173,23 @@ public class CollisionResolverTests
     [Fact]
     public void Overlaps_RectCircle_AgreesWithCircleRect()
     {
-        var circleOwner = new TestEntity { X = 50f, Y = 50f };
-        var rectOwner = new TestEntity { X = 50f, Y = 50f };
         var circle = new CircleCollider { Radius = 5f };
         var rect = new RectCollider { Width = 100f, Height = 100f };
+        var circleOwner = new Entity { X = 50f, Y = 50f, Collider = circle };
+        var rectOwner = new Entity { X = 50f, Y = 50f, Collider = rect };
 
         Assert.Equal(
-            CollisionResolver.Overlaps(circleOwner, circle, rectOwner, rect),
-            CollisionResolver.Overlaps(rectOwner, rect, circleOwner, circle));
+            CollisionResolver.Overlaps(circleOwner, rectOwner),
+            CollisionResolver.Overlaps(rectOwner, circleOwner));
     }
 
     [Fact]
     public void TryGetHit_RectVsCircle_InvertsNormalForFirstCollider()
     {
-        var circleOwner = new TestEntity { X = 3f, Y = 50f };
-        var rectOwner = new TestEntity { X = 50f, Y = 100f };
-        var circle = new CircleCollider { Radius = 8f };
-        var rect = new RectCollider { Width = 100f, Height = 200f };
+        var circleOwner = new Entity { X = 3f, Y = 50f, Collider = new CircleCollider { Radius = 8f } };
+        var rectOwner = new Entity { X = 50f, Y = 100f, Collider = new RectCollider { Width = 100f, Height = 200f } };
 
-        var result = CollisionResolver.TryGetHit(rectOwner, rect, circleOwner, circle, out var hit);
+        var result = CollisionResolver.TryGetHit(rectOwner, circleOwner, out var hit);
 
         Assert.True(result);
         Assert.True(hit.NormalX > 0f);
@@ -214,23 +198,19 @@ public class CollisionResolverTests
     [Fact]
     public void Overlaps_RectRect_WhenSeparated_ReturnsFalse()
     {
-        var a = new TestEntity { X = 0f, Y = 0f };
-        var b = new TestEntity { X = 200f, Y = 200f };
-        var rectA = new RectCollider { Width = 50f, Height = 50f };
-        var rectB = new RectCollider { Width = 50f, Height = 50f };
+        var a = new Entity { X = 0f, Y = 0f, Collider = new RectCollider { Width = 50f, Height = 50f } };
+        var b = new Entity { X = 200f, Y = 200f, Collider = new RectCollider { Width = 50f, Height = 50f } };
 
-        Assert.False(CollisionResolver.Overlaps(a, rectA, b, rectB));
+        Assert.False(CollisionResolver.Overlaps(a, b));
     }
 
     [Fact]
     public void TryGetHit_RectRect_WhenOverlapping_ReturnsCollision()
     {
-        var a = new TestEntity { X = 20f, Y = 20f };
-        var b = new TestEntity { X = 40f, Y = 25f };
-        var rectA = new RectCollider { Width = 50f, Height = 50f };
-        var rectB = new RectCollider { Width = 50f, Height = 50f };
+        var a = new Entity { X = 20f, Y = 20f, Collider = new RectCollider { Width = 50f, Height = 50f } };
+        var b = new Entity { X = 40f, Y = 25f, Collider = new RectCollider { Width = 50f, Height = 50f } };
 
-        var result = CollisionResolver.TryGetHit(a, rectA, b, rectB, out var hit);
+        var result = CollisionResolver.TryGetHit(a, b, out var hit);
 
         Assert.True(result);
         Assert.True(hit.Penetration > 0f);
@@ -239,12 +219,10 @@ public class CollisionResolverTests
     [Fact]
     public void TryGetHit_RectRect_WhenVerticalOverlapIsSmaller_ReturnsVerticalNormal()
     {
-        var a = new TestEntity { X = 20f, Y = 20f };
-        var b = new TestEntity { X = 20f, Y = 55f };
-        var rectA = new RectCollider { Width = 50f, Height = 50f };
-        var rectB = new RectCollider { Width = 50f, Height = 50f };
+        var a = new Entity { X = 20f, Y = 20f, Collider = new RectCollider { Width = 50f, Height = 50f } };
+        var b = new Entity { X = 20f, Y = 55f, Collider = new RectCollider { Width = 50f, Height = 50f } };
 
-        var result = CollisionResolver.TryGetHit(a, rectA, b, rectB, out var hit);
+        var result = CollisionResolver.TryGetHit(a, b, out var hit);
 
         Assert.True(result);
         Assert.True(hit.IsVertical);
@@ -254,13 +232,11 @@ public class CollisionResolverTests
     [Fact]
     public void ReflectOff_CircleRect_BouncesVelocity()
     {
-        var ball = new TestEntity { X = 50f, Y = 19f };
-        var brick = new TestEntity { X = 50f, Y = 31f };
-        var circle = new CircleCollider { Radius = 8f };
-        var rect = new RectCollider { Width = 100f, Height = 22f };
         var body = new Rigidbody2D { VelocityY = 200f };
+        var ball = new Entity { X = 50f, Y = 19f, Collider = new CircleCollider { Radius = 8f }, Rigidbody = body };
+        var brick = new Entity { X = 50f, Y = 31f, Collider = new RectCollider { Width = 100f, Height = 22f } };
 
-        var result = CollisionResolver.ReflectOff(ball, circle, body, brick, rect);
+        var result = ball.BounceOff(brick);
 
         Assert.True(result);
         Assert.True(body.VelocityY < 0f);
@@ -269,13 +245,11 @@ public class CollisionResolverTests
     [Fact]
     public void Reflect_CircleRect_BouncesVelocity()
     {
-        var ball = new TestEntity { X = 50f, Y = 19f };
-        var brick = new TestEntity { X = 50f, Y = 31f };
-        var circle = new CircleCollider { Radius = 8f };
-        var rect = new RectCollider { Width = 100f, Height = 22f };
         var body = new Rigidbody2D { VelocityY = 200f };
+        var ball = new Entity { X = 50f, Y = 19f, Collider = new CircleCollider { Radius = 8f }, Rigidbody = body };
+        var brick = new Entity { X = 50f, Y = 31f, Collider = new RectCollider { Width = 100f, Height = 22f } };
 
-        CollisionResolver.Reflect(ball, circle, body, brick, rect);
+        ball.BounceOff(brick);
 
         Assert.True(body.VelocityY < 0f);
     }
@@ -285,15 +259,15 @@ public class CollisionResolverTests
     {
         // A ball heading left into a thick wall entity on the left edge — same
         // scenario that ResolveBounds used to handle, now done via TryGetHit.
-        var ball = new TestEntity { X = 5f, Y = 50f };
         var circle = new CircleCollider { Radius = 8f };
         var body = new Rigidbody2D { VelocityX = -120f };
+        var ball = new Entity { X = 5f, Y = 50f, Collider = circle };
 
         // Wall sits at x = -50 (centre), width = 100, so its right edge is at x = 0.
-        var wall = new TestEntity { X = -50f, Y = 50f };
         var wallCollider = new RectCollider { Width = 100f, Height = 200f };
+        var wall = new Entity { X = -50f, Y = 50f, Collider = wallCollider };
 
-        Assert.True(CollisionResolver.TryGetHit(ball, circle, wall, wallCollider, out var hit));
+        Assert.True(CollisionResolver.TryGetHit(ball, wall, out var hit));
         body.Bounce(hit);
         Assert.True(body.VelocityX > 0f, "Ball should bounce rightward off the left wall");
     }
@@ -303,11 +277,11 @@ public class CollisionResolverTests
     [Fact]
     public void RectCollider_BoundingBox_MatchesWorldRect()
     {
-        var entity = new TestEntity { X = 100f, Y = 50f };
+        var entity = new Entity { X = 100f, Y = 50f };
         var collider = new RectCollider { Width = 40f, Height = 20f };
 
-        var worldRect = collider.WorldRect(entity);
-        var boundingBox = collider.BoundingBox(entity);
+        var worldRect = collider.WorldRect(entity.X, entity.Y);
+        var boundingBox = collider.BoundingBox(entity.X, entity.Y);
 
         Assert.Equal(worldRect.Left, boundingBox.Left, precision: 4);
         Assert.Equal(worldRect.Top, boundingBox.Top, precision: 4);
@@ -318,10 +292,10 @@ public class CollisionResolverTests
     [Fact]
     public void RectCollider_BoundingBox_WithOffset_IsShifted()
     {
-        var entity = new TestEntity { X = 100f, Y = 100f };
+        var entity = new Entity { X = 100f, Y = 100f };
         var collider = new RectCollider { Width = 20f, Height = 10f, OffsetX = 5f, OffsetY = -5f };
 
-        var box = collider.BoundingBox(entity);
+        var box = collider.BoundingBox(entity.X, entity.Y);
 
         Assert.Equal(95f, box.Left, precision: 4);
         Assert.Equal(90f, box.Top, precision: 4);
@@ -332,10 +306,10 @@ public class CollisionResolverTests
     [Fact]
     public void CircleCollider_WithOffset_WorldCenterIsShifted()
     {
-        var entity = new TestEntity { X = 100f, Y = 100f };
+        var entity = new Entity { X = 100f, Y = 100f };
         var collider = new CircleCollider { Radius = 5f, OffsetX = 10f, OffsetY = -5f };
 
-        var (cx, cy) = collider.WorldCenter(entity);
+        var (cx, cy) = collider.WorldCenter(entity.X, entity.Y);
 
         Assert.Equal(110f, cx, precision: 4);
         Assert.Equal(95f, cy, precision: 4);

--- a/tests/GameEngine.Tests/EntityTests.cs
+++ b/tests/GameEngine.Tests/EntityTests.cs
@@ -1,0 +1,536 @@
+using SkiaSharp;
+using Xunit;
+
+namespace SkiaSharpGames.GameEngine.Tests;
+
+public class EntityTests
+{
+    // ── Position & World Position ─────────────────────────────────────
+
+    [Fact]
+    public void RootEntity_WorldPosition_EqualsLocalPosition()
+    {
+        var entity = new Entity { X = 10f, Y = 20f };
+        Assert.Equal(10f, entity.WorldX);
+        Assert.Equal(20f, entity.WorldY);
+    }
+
+    [Fact]
+    public void ChildEntity_WorldPosition_IsParentPlusLocal()
+    {
+        var parent = new Entity { X = 100f, Y = 200f };
+        var child = new Entity { X = 10f, Y = 20f };
+        parent.AddChild(child);
+
+        Assert.Equal(110f, child.WorldX);
+        Assert.Equal(220f, child.WorldY);
+    }
+
+    [Fact]
+    public void NestedChildren_WorldPosition_AccumulatesAllAncestors()
+    {
+        var root = new Entity { X = 10f, Y = 10f };
+        var mid = new Entity { X = 20f, Y = 20f };
+        var leaf = new Entity { X = 5f, Y = 5f };
+        root.AddChild(mid);
+        mid.AddChild(leaf);
+
+        Assert.Equal(35f, leaf.WorldX);
+        Assert.Equal(35f, leaf.WorldY);
+    }
+
+    [Fact]
+    public void ParentPositionChange_PropagatesWorldToChildren()
+    {
+        var parent = new Entity { X = 0f, Y = 0f };
+        var child = new Entity { X = 10f, Y = 10f };
+        parent.AddChild(child);
+
+        Assert.Equal(10f, child.WorldX);
+
+        parent.X = 50f;
+        Assert.Equal(60f, child.WorldX);
+        Assert.Equal(10f, child.WorldY);
+    }
+
+    [Fact]
+    public void ChildPositionChange_UpdatesOwnWorldOnly()
+    {
+        var parent = new Entity { X = 100f, Y = 200f };
+        var child1 = new Entity { X = 10f, Y = 10f };
+        var child2 = new Entity { X = 20f, Y = 20f };
+        parent.AddChild(child1);
+        parent.AddChild(child2);
+
+        child1.X = 50f;
+        Assert.Equal(150f, child1.WorldX);
+        Assert.Equal(120f, child2.WorldX); // unchanged
+    }
+
+    // ── Rotation ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void RootEntity_WorldRotation_EqualsLocalRotation()
+    {
+        var entity = new Entity { Rotation = MathF.PI / 4f };
+        Assert.Equal(MathF.PI / 4f, entity.WorldRotation);
+    }
+
+    [Fact]
+    public void ParentRotation_AffectsChildWorldPosition()
+    {
+        var parent = new Entity { X = 0f, Y = 0f, Rotation = MathF.PI / 2f }; // 90°
+        var child = new Entity { X = 10f, Y = 0f };
+        parent.AddChild(child);
+
+        // 90° rotation: (10, 0) → (0, 10)
+        Assert.Equal(0f, child.WorldX, 1e-4f);
+        Assert.Equal(10f, child.WorldY, 1e-4f);
+    }
+
+    [Fact]
+    public void ParentRotation_AccumulatesChildRotation()
+    {
+        var parent = new Entity { Rotation = MathF.PI / 4f };
+        var child = new Entity { Rotation = MathF.PI / 4f };
+        parent.AddChild(child);
+
+        Assert.Equal(MathF.PI / 2f, child.WorldRotation, 1e-5f);
+    }
+
+    [Fact]
+    public void NoParentRotation_UsesSimpleAddition()
+    {
+        // Tests the fast path (no trig)
+        var parent = new Entity { X = 100f, Y = 100f }; // rotation = 0
+        var child = new Entity { X = 50f, Y = 50f };
+        parent.AddChild(child);
+
+        Assert.Equal(150f, child.WorldX);
+        Assert.Equal(150f, child.WorldY);
+        Assert.Equal(0f, child.WorldRotation);
+    }
+
+    // ── Children ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddChild_SetsParentAndRecalculatesWorld()
+    {
+        var parent = new Entity { X = 100f, Y = 100f };
+        var child = new Entity { X = 10f, Y = 10f };
+
+        parent.AddChild(child);
+
+        Assert.Same(parent, child.Parent);
+        Assert.Single(parent.Children);
+        Assert.Equal(110f, child.WorldX);
+    }
+
+    [Fact]
+    public void AddChild_RemovesFromPreviousParent()
+    {
+        var parent1 = new Entity();
+        var parent2 = new Entity { X = 50f, Y = 50f };
+        var child = new Entity { X = 10f, Y = 10f };
+
+        parent1.AddChild(child);
+        Assert.Single(parent1.Children);
+
+        parent2.AddChild(child);
+        Assert.Empty(parent1.Children);
+        Assert.Single(parent2.Children);
+        Assert.Same(parent2, child.Parent);
+        Assert.Equal(60f, child.WorldX);
+    }
+
+    [Fact]
+    public void RemoveChild_ClearsParentAndRecalculates()
+    {
+        var parent = new Entity { X = 100f, Y = 100f };
+        var child = new Entity { X = 10f, Y = 10f };
+        parent.AddChild(child);
+
+        parent.RemoveChild(child);
+
+        Assert.Null(child.Parent);
+        Assert.Empty(parent.Children);
+        Assert.Equal(10f, child.WorldX); // now root
+    }
+
+    [Fact]
+    public void RemoveInactiveChildren_RemovesOnlyInactive()
+    {
+        var parent = new Entity();
+        var active = new Entity { Active = true };
+        var inactive = new Entity { Active = false };
+        parent.AddChild(active);
+        parent.AddChild(inactive);
+
+        int removed = parent.RemoveInactiveChildren();
+
+        Assert.Equal(1, removed);
+        Assert.Single(parent.Children);
+        Assert.Same(active, parent.Children[0]);
+        Assert.Null(inactive.Parent);
+    }
+
+    [Fact]
+    public void ChildCount_ReflectsChildren()
+    {
+        var parent = new Entity();
+        Assert.Equal(0, parent.ChildCount);
+
+        parent.AddChild(new Entity());
+        parent.AddChild(new Entity());
+        Assert.Equal(2, parent.ChildCount);
+    }
+
+    // ── Update ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Update_StepsRigidbody()
+    {
+        var entity = new Entity
+        {
+            X = 0f, Y = 0f,
+            Rigidbody = new Rigidbody2D { VelocityX = 100f, VelocityY = 50f }
+        };
+
+        entity.Update(0.5f);
+
+        Assert.Equal(50f, entity.X);
+        Assert.Equal(25f, entity.Y);
+    }
+
+    [Fact]
+    public void Update_RecursesIntoActiveChildren()
+    {
+        var parent = new Entity();
+        var child = new Entity
+        {
+            Rigidbody = new Rigidbody2D { VelocityX = 10f }
+        };
+        parent.AddChild(child);
+
+        parent.Update(1f);
+
+        Assert.Equal(10f, child.X);
+    }
+
+    [Fact]
+    public void Update_SkipsInactiveEntities()
+    {
+        var entity = new Entity
+        {
+            Active = false,
+            Rigidbody = new Rigidbody2D { VelocityX = 100f }
+        };
+
+        entity.Update(1f);
+
+        Assert.Equal(0f, entity.X);
+    }
+
+    [Fact]
+    public void Update_CallsOnUpdate()
+    {
+        var entity = new TestEntity();
+        entity.Update(0.5f);
+        Assert.True(entity.OnUpdateCalled);
+        Assert.Equal(0.5f, entity.LastDeltaTime);
+    }
+
+    // ── Draw ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Draw_SkipsInvisibleEntity()
+    {
+        var entity = new Entity { Visible = false, Sprite = new TrackingSprite() };
+        using var surface = SKSurface.Create(new SKImageInfo(100, 100));
+        entity.Draw(surface.Canvas);
+        Assert.False(((TrackingSprite)entity.Sprite).DrawCalled);
+    }
+
+    [Fact]
+    public void Draw_SkipsInactiveEntity()
+    {
+        var entity = new Entity { Active = false, Sprite = new TrackingSprite() };
+        using var surface = SKSurface.Create(new SKImageInfo(100, 100));
+        entity.Draw(surface.Canvas);
+        Assert.False(((TrackingSprite)entity.Sprite).DrawCalled);
+    }
+
+    [Fact]
+    public void Draw_DrawsSprite()
+    {
+        var sprite = new TrackingSprite();
+        var entity = new Entity { Sprite = sprite };
+        using var surface = SKSurface.Create(new SKImageInfo(100, 100));
+        entity.Draw(surface.Canvas);
+        Assert.True(sprite.DrawCalled);
+    }
+
+    [Fact]
+    public void Draw_RecursesIntoChildren()
+    {
+        var childSprite = new TrackingSprite();
+        var parent = new Entity();
+        var child = new Entity { Sprite = childSprite };
+        parent.AddChild(child);
+
+        using var surface = SKSurface.Create(new SKImageInfo(100, 100));
+        parent.Draw(surface.Canvas);
+        Assert.True(childSprite.DrawCalled);
+    }
+
+    // ── Collision Helpers ─────────────────────────────────────────────
+
+    [Fact]
+    public void Overlaps_ReturnsTrueForOverlappingEntities()
+    {
+        var a = new Entity { X = 0f, Y = 0f, Collider = new CircleCollider { Radius = 10f } };
+        var b = new Entity { X = 5f, Y = 0f, Collider = new CircleCollider { Radius = 10f } };
+
+        Assert.True(a.Overlaps(b));
+    }
+
+    [Fact]
+    public void Overlaps_ReturnsFalseForDistantEntities()
+    {
+        var a = new Entity { X = 0f, Y = 0f, Collider = new CircleCollider { Radius = 5f } };
+        var b = new Entity { X = 100f, Y = 0f, Collider = new CircleCollider { Radius = 5f } };
+
+        Assert.False(a.Overlaps(b));
+    }
+
+    [Fact]
+    public void Overlaps_ReturnsFalseWithoutCollider()
+    {
+        var a = new Entity { X = 0f, Y = 0f };
+        var b = new Entity { X = 0f, Y = 0f, Collider = new CircleCollider { Radius = 10f } };
+
+        Assert.False(a.Overlaps(b));
+    }
+
+    [Fact]
+    public void BounceOff_ReflectsVelocity()
+    {
+        var ball = new Entity
+        {
+            X = 5f, Y = 0f,
+            Collider = new CircleCollider { Radius = 10f },
+            Rigidbody = new Rigidbody2D { VelocityX = -100f }
+        };
+        var wall = new Entity
+        {
+            X = 0f, Y = 0f,
+            Collider = new RectCollider { Width = 2f, Height = 100f }
+        };
+
+        bool bounced = ball.BounceOff(wall);
+        Assert.True(bounced);
+        Assert.True(ball.Rigidbody.VelocityX > 0); // reflected
+    }
+
+    [Fact]
+    public void BounceOff_ReturnsFalseWithoutRigidbody()
+    {
+        var a = new Entity { Collider = new CircleCollider { Radius = 10f } };
+        var b = new Entity { Collider = new CircleCollider { Radius = 10f } };
+
+        Assert.False(a.BounceOff(b));
+    }
+
+    // ── WorldBoundingBox ──────────────────────────────────────────────
+
+    [Fact]
+    public void WorldBoundingBox_NullWithoutCollider()
+    {
+        var entity = new Entity { X = 10f, Y = 10f };
+        Assert.Null(entity.WorldBoundingBox);
+    }
+
+    [Fact]
+    public void WorldBoundingBox_UsesWorldPosition()
+    {
+        var parent = new Entity { X = 100f, Y = 100f };
+        var child = new Entity
+        {
+            X = 10f, Y = 10f,
+            Collider = new RectCollider { Width = 20f, Height = 20f }
+        };
+        parent.AddChild(child);
+
+        var bb = child.WorldBoundingBox;
+        Assert.NotNull(bb);
+        // World pos is (110, 110), rect centered → (100, 100) to (120, 120)
+        Assert.Equal(100f, bb.Value.Left);
+        Assert.Equal(100f, bb.Value.Top);
+        Assert.Equal(120f, bb.Value.Right);
+        Assert.Equal(120f, bb.Value.Bottom);
+    }
+
+    [Fact]
+    public void WorldBoundingBox_WithRotation_ReturnsConservativeAABB()
+    {
+        var entity = new Entity
+        {
+            X = 0f, Y = 0f,
+            Rotation = MathF.PI / 4f, // 45°
+            Collider = new RectCollider { Width = 10f, Height = 10f }
+        };
+
+        var bb = entity.WorldBoundingBox;
+        Assert.NotNull(bb);
+        // 45° rotated 10x10 rect has AABB larger than 10x10
+        Assert.True(bb.Value.Width > 10f);
+        Assert.True(bb.Value.Height > 10f);
+    }
+
+    // ── ChildrenBoundingBox ───────────────────────────────────────────
+
+    [Fact]
+    public void ChildrenBoundingBox_NullWithNoChildren()
+    {
+        var entity = new Entity();
+        Assert.Null(entity.ChildrenBoundingBox);
+    }
+
+    [Fact]
+    public void ChildrenBoundingBox_EnclosesAllActiveChildren()
+    {
+        var parent = new Entity();
+        parent.AddChild(new Entity
+        {
+            X = 0f, Y = 0f,
+            Collider = new RectCollider { Width = 10f, Height = 10f }
+        });
+        parent.AddChild(new Entity
+        {
+            X = 100f, Y = 0f,
+            Collider = new RectCollider { Width = 10f, Height = 10f }
+        });
+
+        var bb = parent.ChildrenBoundingBox;
+        Assert.NotNull(bb);
+        Assert.Equal(-5f, bb.Value.Left);
+        Assert.Equal(105f, bb.Value.Right);
+    }
+
+    [Fact]
+    public void ChildrenBoundingBox_SkipsInactiveChildren()
+    {
+        var parent = new Entity();
+        parent.AddChild(new Entity
+        {
+            X = 0f, Y = 0f,
+            Collider = new RectCollider { Width = 10f, Height = 10f }
+        });
+        parent.AddChild(new Entity
+        {
+            X = 1000f, Y = 0f, Active = false,
+            Collider = new RectCollider { Width = 10f, Height = 10f }
+        });
+
+        var bb = parent.ChildrenBoundingBox;
+        Assert.NotNull(bb);
+        Assert.True(bb.Value.Right < 100f); // far-away inactive child excluded
+    }
+
+    // ── FindChildCollision ────────────────────────────────────────────
+
+    [Fact]
+    public void FindChildCollision_FindsOverlappingChild()
+    {
+        var parent = new Entity();
+        var brick = new Entity
+        {
+            X = 50f, Y = 50f,
+            Collider = new RectCollider { Width = 20f, Height = 20f }
+        };
+        parent.AddChild(brick);
+
+        var ball = new Entity
+        {
+            X = 55f, Y = 55f,
+            Collider = new CircleCollider { Radius = 5f }
+        };
+
+        var hit = parent.FindChildCollision(ball, out _);
+        Assert.Same(brick, hit);
+    }
+
+    [Fact]
+    public void FindChildCollision_ReturnsNullWhenNoOverlap()
+    {
+        var parent = new Entity();
+        parent.AddChild(new Entity
+        {
+            X = 50f, Y = 50f,
+            Collider = new RectCollider { Width = 20f, Height = 20f }
+        });
+
+        var ball = new Entity
+        {
+            X = 500f, Y = 500f,
+            Collider = new CircleCollider { Radius = 5f }
+        };
+
+        var hit = parent.FindChildCollision(ball, out _);
+        Assert.Null(hit);
+    }
+
+    [Fact]
+    public void FindChildCollision_SkipsInactiveChildren()
+    {
+        var parent = new Entity();
+        parent.AddChild(new Entity
+        {
+            X = 0f, Y = 0f, Active = false,
+            Collider = new RectCollider { Width = 100f, Height = 100f }
+        });
+
+        var ball = new Entity
+        {
+            X = 0f, Y = 0f,
+            Collider = new CircleCollider { Radius = 5f }
+        };
+
+        Assert.Null(parent.FindChildCollision(ball, out _));
+    }
+
+    [Fact]
+    public void FindChildCollision_ReturnsNullWhenOtherHasNoCollider()
+    {
+        var parent = new Entity();
+        parent.AddChild(new Entity
+        {
+            X = 0f, Y = 0f,
+            Collider = new RectCollider { Width = 100f, Height = 100f }
+        });
+
+        var noCollider = new Entity { X = 0f, Y = 0f };
+
+        Assert.Null(parent.FindChildCollision(noCollider, out _));
+    }
+
+    // ── Test helpers ──────────────────────────────────────────────────
+
+    private sealed class TestEntity : Entity
+    {
+        public bool OnUpdateCalled;
+        public float LastDeltaTime;
+
+        protected override void OnUpdate(float deltaTime)
+        {
+            OnUpdateCalled = true;
+            LastDeltaTime = deltaTime;
+        }
+    }
+
+    private sealed class TrackingSprite : Sprite
+    {
+        public bool DrawCalled;
+        public override void Draw(SKCanvas canvas) => DrawCalled = true;
+    }
+}

--- a/tests/GameEngine.Tests/SpriteTests.cs
+++ b/tests/GameEngine.Tests/SpriteTests.cs
@@ -10,11 +10,11 @@ file sealed class TestSprite : Sprite
 
     public bool DrawCalled { get; private set; }
 
-    public override void Draw(SKCanvas canvas, float x, float y)
+    public override void Draw(SKCanvas canvas)
     {
         DrawCalled = true;
         FillPaint.Color = SKColors.White;
-        canvas.DrawCircle(x, y, 4f, FillPaint);
+        canvas.DrawCircle(0f, 0f, 4f, FillPaint);
     }
 }
 
@@ -27,7 +27,7 @@ public class SpriteTests
         using var bitmap = new SKBitmap(200, 200);
         using var canvas = new SKCanvas(bitmap);
 
-        sprite.Draw(canvas, 20f, 20f);
+        sprite.Draw(canvas);
 
         Assert.True(sprite.DrawCalled);
     }
@@ -69,7 +69,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = "Score: 100", Size = 20f, Color = SKColors.White };
         using var bmp = new SKBitmap(400, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 10f, 30f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 
@@ -79,7 +79,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = "TITLE", Size = 32f, Align = TextAlign.Center };
         using var bmp = new SKBitmap(400, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 200f, 100f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 
@@ -89,7 +89,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = "Lives: 3", Size = 20f, Align = TextAlign.Right };
         using var bmp = new SKBitmap(400, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 380f, 30f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 
@@ -99,7 +99,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = "", Size = 16f };
         using var bmp = new SKBitmap(200, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 10f, 10f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 
@@ -109,7 +109,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = null!, Size = 16f };
         using var bmp = new SKBitmap(200, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 10f, 10f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 
@@ -119,7 +119,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = "Hello", Size = 16f, Visible = false };
         using var bmp = new SKBitmap(200, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 10f, 10f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 
@@ -129,7 +129,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = "Hello", Size = 16f, Alpha = 0f };
         using var bmp = new SKBitmap(200, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 10f, 10f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 
@@ -154,7 +154,7 @@ public class SpriteTests
         var ts = new TextSprite { Text = "Hi", Size = 16f, Alpha = 2f };
         using var bmp = new SKBitmap(200, 200);
         using var canvas = new SKCanvas(bmp);
-        var ex = Record.Exception(() => ts.Draw(canvas, 10f, 10f));
+        var ex = Record.Exception(() => ts.Draw(canvas));
         Assert.Null(ex);
     }
 }


### PR DESCRIPTION
## What changed

The engine's `Entity` was a minimal abstract class with just `X`, `Y`, and `Active`. Each game entity had to manually compose separate `Sprite`, `Collider2D`, and `Rigidbody2D` objects as readonly fields, and every screen had to manually wire up `sprite.Draw(canvas, x, y)`, `rigidbody.Step(entity, dt)`, and `CollisionResolver.TryGetHit(entity, collider, other, otherCollider, out hit)` calls. Entities were flat — no parent-child hierarchy, no grouping, no automatic draw traversal.

This PR makes `Entity` the universal building block.

### Entity gains children and components

- **Parenting**: `AddChild()`/`RemoveChild()` with automatic world-position propagation. Any entity can have children.
- **Components**: Nullable `Sprite?`, `Collider?`, `Rigidbody?` properties on Entity itself. Subclasses set them in constructors and provide typed `new` accessors.
- **Rotation**: `Rotation` property (radians) with full world-rotation support. Parent rotation orbits child positions.
- **WorldX/WorldY/WorldRotation**: Cached, recalculated from the parent chain on change. No float drift.
- **Recursive Update**: steps rigidbody → updates sprite → `OnUpdate()` hook → recurses children.
- **Recursive Draw**: translates → rotates → draws sprite → recurses children.
- **Collision helpers**: `entity.Overlaps(other)`, `entity.TryGetHit(other, out hit)`, `entity.BounceOff(other)`.
- **Child queries**: `ChildrenBoundingBox` (aggregate AABB), `FindChildCollision(other, out hit)` with broad-phase skip.

### Sprite and Collider APIs simplified

- `Sprite.Draw(SKCanvas)` — no more x/y params. Canvas already translated by Entity.Draw.
- `Collider2D.BoundingBox(float cx, float cy)` — explicit position.
- `CollisionResolver.Overlaps(Entity, Entity)` and `TryGetHit(Entity, Entity)` — reads WorldX/Y directly.

### All 7 existing games migrated

- **Breakout**: `_bricks` parent with children. `_bricks.FindChildCollision(_ball)`. `_ball.BounceOff(wall)`.
- **Space Invaders**: Formation entity with invader children. Shield hierarchy. `ChildrenBoundingBox` for edge detection. 4 new sprite classes.
- **CastleAttack, Pong, Catch, SinkSub**: Entity groups, direct collision API.
- **2048**: Unchanged (no entities).

### New game: Lunar Lander

Demonstrates rotation + child entities:
- Lander has 3 child flame entities that **orbit with the lander's rotation** via canvas transform stacking.
- Thrust vector uses `WorldRotation`. Procedural terrain, fuel management, on-screen touch control pad.

### Stats

- 18 commits, 98 files changed, +2650 / -916 lines
- 216 tests (37 new), 98% line / 89% branch / 99% method coverage