### PR TITLE
Add Snake game

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The goal of this repo is not to build a giant engine. It is to keep a tiny, read
 
 📘 **Engine reference:** [docs/game-engine.md](docs/game-engine.md)
 
-🕹️ **Gameplay docs:** [Breakout](docs/games/breakout.md) · [Castle Attack](docs/games/castle-attack.md) · [Sink Sub](docs/games/sink-sub.md) · [2048](docs/games/2048.md)
+🕹️ **Gameplay docs:** [Breakout](docs/games/breakout.md) · [Castle Attack](docs/games/castle-attack.md) · [Sink Sub](docs/games/sink-sub.md) · [Snake](docs/games/snake.md) · [2048](docs/games/2048.md)
 
 ## Games
 
@@ -17,6 +17,7 @@ The goal of this repo is not to build a giant engine. It is to keep a tiny, read
 | [Breakout](src/BlazorApp/Games/Breakout/) | `/games/breakout` | Classic brick-breaker with power-ups and paddle-angle control. |
 | [Castle Attack](src/BlazorApp/Games/CastleAttack/) | `/games/castle-attack` | Defend layered castle walls with archers, workers, and special weapons. |
 | [Sink Sub](src/BlazorApp/Games/SinkSub/) | `/games/sink-sub` | Patrol the surface, drop depth charges, and sink submarines before their mines hit your ship. |
+| [Snake](src/Snake/) | `/games/snake` | Guide the snake to eat food and grow. Don't crash into walls or your own tail! |
 | [2048](src/TwoZeroFourEight/) | `/games/2048` | Slide tiles on a 4×4 grid, merge matching numbers, and reach the 2048 tile. |
 
 ### Breakout
@@ -108,6 +109,11 @@ src/
     PlayScreen.cs, StartScreen.cs, GameOverScreen.cs
     TextRenderer.cs
 
+  Snake/                        # SkiaSharpGames.Snake class library
+    SnakeGame.cs
+    PlayScreen.cs, StartScreen.cs, GameOverScreen.cs
+    Direction.cs, GridPoint.cs, SnakeConstants.cs, SnakeGameState.cs
+
   TwoZeroFourEight/             # SkiaSharpGames.TwoZeroFourEight class library
     TwoZeroFourEightGame.cs
     PlayScreen.cs, StartScreen.cs, GameOverScreen.cs
@@ -119,6 +125,7 @@ src/
         Breakout.razor
         CastleAttack.razor
         SinkSub.razor
+        Snake.razor
         TwoZeroFourEight.razor
     Shared/
       GameView.razor

--- a/SkiaSharpGames.slnx
+++ b/SkiaSharpGames.slnx
@@ -30,6 +30,9 @@
   <Folder Name="/src/LunarLander/">
     <Project Path="src/LunarLander/SkiaSharpGames.LunarLander.csproj" />
   </Folder>
+  <Folder Name="/src/Snake/">
+    <Project Path="src/Snake/SkiaSharpGames.Snake.csproj" />
+  </Folder>
   <Folder Name="/tests/" />
   <Folder Name="/tests/GameEngine.Tests/">
     <Project Path="tests/GameEngine.Tests/SkiaSharpGames.GameEngine.Tests.csproj" />

--- a/docs/games/snake.md
+++ b/docs/games/snake.md
@@ -1,0 +1,32 @@
+# Snake gameplay guide
+
+## Overview
+
+Classic snake game — steer the snake around a grid, eat food to grow, and avoid crashing.
+
+## Objective
+
+Eat as much food as possible without hitting the walls or your own tail.
+
+## Controls
+
+| Input | Action |
+|-------|--------|
+| Arrow keys | Steer up / down / left / right |
+| W / A / S / D | Steer up / left / down / right |
+| Click / tap | Steer towards the tap relative to the snake's head |
+
+## Gameplay rules
+
+- The snake moves on a 25 × 25 grid at a fixed step rate.
+- Eating the red food grows the snake by one segment and adds a point.
+- Each food eaten slightly increases the snake's speed.
+- Hitting a wall edge or any part of your own body ends the game.
+- Your highest score is tracked for the session.
+
+## Screenshots
+
+| Desktop | Mobile |
+|---------|--------|
+| ![Desktop - Start screen](../screenshots/snake/desktop-loading.png) | ![Mobile - Start screen](../screenshots/snake/mobile-loading.png) |
+| ![Desktop - Gameplay](../screenshots/snake/desktop-gameplay.png) | ![Mobile - Gameplay](../screenshots/snake/mobile-gameplay.png) |

--- a/src/BlazorApp/Pages/Games/Snake.razor
+++ b/src/BlazorApp/Pages/Games/Snake.razor
@@ -1,0 +1,15 @@
+@page "/games/snake"
+@layout GameLayout
+
+<PageTitle>Snake – SkiaSharp Games</PageTitle>
+
+<GameView Game="_game" />
+
+@code {
+    private readonly Game _game;
+
+    public Snake([FromKeyedServices("snake")] Game game)
+    {
+        _game = game;
+    }
+}

--- a/src/BlazorApp/Pages/Home.razor
+++ b/src/BlazorApp/Pages/Home.razor
@@ -78,6 +78,16 @@
             <span class="game-card-play">▶ Play</span>
         </div>
     </a>
+    <a class="game-card" href="games/snake">
+        <div class="game-card-banner">
+            <span class="game-card-emoji">🐍</span>
+        </div>
+        <div class="game-card-info">
+            <h2 class="game-card-title">Snake</h2>
+            <p class="game-card-desc">Guide the snake to eat food and grow longer. Don't crash into the walls or your own tail!</p>
+            <span class="game-card-play">▶ Play</span>
+        </div>
+    </a>
     <a class="game-card" href="games/lunar-lander">
         <div class="game-card-banner">
             <span class="game-card-emoji">🚀</span>

--- a/src/BlazorApp/Pages/Home.razor
+++ b/src/BlazorApp/Pages/Home.razor
@@ -80,7 +80,7 @@
     </a>
     <a class="game-card" href="games/snake">
         <div class="game-card-banner">
-            <span class="game-card-emoji">🐍</span>
+            <span class="game-card-emoji">~S~</span>
         </div>
         <div class="game-card-info">
             <h2 class="game-card-title">Snake</h2>

--- a/src/BlazorApp/Pages/Home.razor
+++ b/src/BlazorApp/Pages/Home.razor
@@ -80,7 +80,7 @@
     </a>
     <a class="game-card" href="games/snake">
         <div class="game-card-banner">
-            <span class="game-card-emoji">~S~</span>
+            <span class="game-card-emoji">🐍</span>
         </div>
         <div class="game-card-info">
             <h2 class="game-card-title">Snake</h2>

--- a/src/BlazorApp/Program.cs
+++ b/src/BlazorApp/Program.cs
@@ -9,6 +9,7 @@ using SkiaSharpGames.TwoZeroFourEight;
 using SkiaSharpGames.SpaceInvaders;
 using SkiaSharpGames.Catch;
 using SkiaSharpGames.LunarLander;
+using SkiaSharpGames.Snake;
 using SkiaSharpGames.GameEngine;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -27,5 +28,6 @@ builder.Services.AddKeyedTransient<Game>("2048", (sp, _) => TwoZeroFourEightGame
 builder.Services.AddKeyedTransient<Game>("space-invaders", (sp, _) => SpaceInvadersGame.Create());
 builder.Services.AddKeyedTransient<Game>("catch", (sp, _) => CatchGame.Create());
 builder.Services.AddKeyedTransient<Game>("lunar-lander", (sp, _) => LunarLanderGame.Create());
+builder.Services.AddKeyedTransient<Game>("snake", (sp, _) => SnakeGame.Create());
 
 await builder.Build().RunAsync();

--- a/src/BlazorApp/SkiaSharpGames.BlazorApp.csproj
+++ b/src/BlazorApp/SkiaSharpGames.BlazorApp.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\SpaceInvaders\SkiaSharpGames.SpaceInvaders.csproj" />
     <ProjectReference Include="..\Catch\SkiaSharpGames.Catch.csproj" />
     <ProjectReference Include="..\LunarLander\SkiaSharpGames.LunarLander.csproj" />
+    <ProjectReference Include="..\Snake\SkiaSharpGames.Snake.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Snake/CellSprite.cs
+++ b/src/Snake/CellSprite.cs
@@ -1,0 +1,27 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+/// <summary>Draws a single rounded-rect cell, centred at the entity origin.</summary>
+internal sealed class CellSprite : Sprite
+{
+    private static readonly SKPaint _paint = new() { IsAntialias = true };
+
+    public SKColor Color { get; set; } = SKColors.White;
+
+    public float Inset { get; set; } = 2f;
+
+    public float CornerRadius { get; set; } = 6f;
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible || Alpha <= 0f)
+            return;
+
+        float size = CellSize - Inset * 2f;
+        _paint.Color = Color.WithAlpha((byte)(255 * Alpha));
+        canvas.DrawRoundRect(-size / 2f, -size / 2f, size, size, CornerRadius, CornerRadius, _paint);
+    }
+}

--- a/src/Snake/Direction.cs
+++ b/src/Snake/Direction.cs
@@ -1,0 +1,9 @@
+namespace SkiaSharpGames.Snake;
+
+internal enum Direction
+{
+    Up,
+    Down,
+    Left,
+    Right,
+}

--- a/src/Snake/FoodEntity.cs
+++ b/src/Snake/FoodEntity.cs
@@ -1,0 +1,27 @@
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+/// <summary>The food pickup. Positions itself on a grid cell and has a collider for overlap tests.</summary>
+internal sealed class FoodEntity : Entity
+{
+    public FoodEntity()
+    {
+        Sprite = new CellSprite { Color = FoodColor, Inset = 2f, CornerRadius = 6f };
+        Collider = new RectCollider { Width = CellSize, Height = CellSize };
+    }
+
+    public GridPoint Cell { get; private set; }
+
+    public new CellSprite Sprite { get => (CellSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+
+    /// <summary>Place the food on <paramref name="cell"/>.</summary>
+    public void PlaceAt(GridPoint cell)
+    {
+        Cell = cell;
+        X = cell.Col * CellSize + CellSize / 2f;
+        Y = cell.Row * CellSize + CellSize / 2f;
+    }
+}

--- a/src/Snake/GameOverScreen.cs
+++ b/src/Snake/GameOverScreen.cs
@@ -1,0 +1,44 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+internal sealed class GameOverScreen(SnakeGameState state, IScreenCoordinator coordinator) : GameScreen
+{
+    private static readonly SKPaint _overlayPaint = new() { Color = SKColors.Black.WithAlpha((byte)(255 * 0.8f)) };
+
+    private readonly TextSprite _titleText = new() { Text = "GAME OVER", Size = 72f, Color = DangerColor, Align = TextAlign.Center };
+    private readonly TextSprite _scoreText = new() { Size = 34f, Align = TextAlign.Center };
+    private readonly TextSprite _highScoreText = new() { Size = 24f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _promptText = new() { Text = "Click, tap, or press Space to try again", Size = 24f, Color = AccentColor, Align = TextAlign.Center };
+
+    public override void Draw(SKCanvas canvas, int width, int height)
+    {
+        canvas.DrawRect(0, 0, GameWidth, GameHeight, _overlayPaint);
+
+        float cx = GameWidth / 2f;
+
+        canvas.Save(); canvas.Translate(cx, 220f); _titleText.Draw(canvas); canvas.Restore();
+
+        _scoreText.Text = $"Score: {state.Score}";
+        canvas.Save(); canvas.Translate(cx, 300f); _scoreText.Draw(canvas); canvas.Restore();
+
+        if (state.HighScore > 0)
+        {
+            _highScoreText.Text = $"Best: {state.HighScore}";
+            canvas.Save(); canvas.Translate(cx, 345f); _highScoreText.Draw(canvas); canvas.Restore();
+        }
+
+        canvas.Save(); canvas.Translate(cx, 420f); _promptText.Draw(canvas); canvas.Restore();
+    }
+
+    public override void OnPointerDown(float x, float y) =>
+        coordinator.TransitionTo<StartScreen>(new DissolveTransition());
+
+    public override void OnKeyDown(string key)
+    {
+        if (key is " " or "Enter")
+            coordinator.TransitionTo<StartScreen>(new DissolveTransition());
+    }
+}

--- a/src/Snake/GridPoint.cs
+++ b/src/Snake/GridPoint.cs
@@ -1,0 +1,3 @@
+namespace SkiaSharpGames.Snake;
+
+internal readonly record struct GridPoint(int Col, int Row);

--- a/src/Snake/GridSprite.cs
+++ b/src/Snake/GridSprite.cs
@@ -1,0 +1,29 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+/// <summary>Draws the background grid lines.</summary>
+internal sealed class GridSprite : Sprite
+{
+    private static readonly SKPaint _linePaint = new() { Color = GridLineColor, StrokeWidth = 1f, IsAntialias = true };
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible || Alpha <= 0f)
+            return;
+
+        for (int c = 1; c < GridCols; c++)
+        {
+            float x = c * CellSize;
+            canvas.DrawLine(x, 0, x, GameHeight, _linePaint);
+        }
+
+        for (int r = 1; r < GridRows; r++)
+        {
+            float y = r * CellSize;
+            canvas.DrawLine(0, y, GameWidth, y, _linePaint);
+        }
+    }
+}

--- a/src/Snake/PlayScreen.cs
+++ b/src/Snake/PlayScreen.cs
@@ -52,8 +52,9 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
 
     public override void OnPointerDown(float x, float y)
     {
-        float hx = _snake.X;
-        float hy = _snake.Y;
+        var head = _snake.Head;
+        float hx = head.Col * CellSize + CellSize / 2f;
+        float hy = head.Row * CellSize + CellSize / 2f;
 
         float dx = x - hx;
         float dy = y - hy;

--- a/src/Snake/PlayScreen.cs
+++ b/src/Snake/PlayScreen.cs
@@ -1,0 +1,230 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordinator) : GameScreen
+{
+    private static readonly SKPaint _cellPaint = new() { IsAntialias = true };
+    private static readonly SKPaint _gridPaint = new() { Color = GridLineColor, StrokeWidth = 1f, IsAntialias = true };
+
+    private readonly TextSprite _scoreText = new() { Size = 22f };
+    private readonly TextSprite _highScoreText = new() { Size = 18f, Color = DimColor, Align = TextAlign.Right };
+
+    private readonly LinkedList<GridPoint> _body = new();
+    private Direction _direction;
+    private Direction _nextDirection;
+    private GridPoint _food;
+    private float _stepTimer;
+    private float _stepInterval;
+    private bool _gameOverShown;
+
+    public override void OnActivated()
+    {
+        state.Score = 0;
+        _stepInterval = InitialStepInterval;
+        _stepTimer = 0f;
+        _gameOverShown = false;
+
+        _body.Clear();
+        int startCol = GridCols / 2;
+        int startRow = GridRows / 2;
+        _body.AddFirst(new GridPoint(startCol, startRow));
+        _body.AddLast(new GridPoint(startCol - 1, startRow));
+        _body.AddLast(new GridPoint(startCol - 2, startRow));
+
+        _direction = Direction.Right;
+        _nextDirection = Direction.Right;
+
+        SpawnFood();
+    }
+
+    // ── Input ─────────────────────────────────────────────────────────────
+
+    public override void OnKeyDown(string key)
+    {
+        var desired = key switch
+        {
+            "ArrowUp" or "w" or "W" => Direction.Up,
+            "ArrowDown" or "s" or "S" => Direction.Down,
+            "ArrowLeft" or "a" or "A" => Direction.Left,
+            "ArrowRight" or "d" or "D" => Direction.Right,
+            _ => (Direction?)null,
+        };
+
+        if (desired is not null && !IsOpposite(desired.Value, _direction))
+            _nextDirection = desired.Value;
+    }
+
+    public override void OnPointerDown(float x, float y)
+    {
+        var head = _body.First!.Value;
+        float hx = head.Col * CellSize + CellSize / 2f;
+        float hy = head.Row * CellSize + CellSize / 2f;
+
+        float dx = x - hx;
+        float dy = y - hy;
+
+        Direction desired;
+        if (MathF.Abs(dx) > MathF.Abs(dy))
+            desired = dx > 0 ? Direction.Right : Direction.Left;
+        else
+            desired = dy > 0 ? Direction.Down : Direction.Up;
+
+        if (!IsOpposite(desired, _direction))
+            _nextDirection = desired;
+    }
+
+    // ── Update ────────────────────────────────────────────────────────────
+
+    public override void Update(float deltaTime)
+    {
+        _stepTimer += deltaTime;
+
+        if (_stepTimer < _stepInterval)
+            return;
+
+        _stepTimer -= _stepInterval;
+        _direction = _nextDirection;
+
+        var head = _body.First!.Value;
+        var next = _direction switch
+        {
+            Direction.Up => new GridPoint(head.Col, head.Row - 1),
+            Direction.Down => new GridPoint(head.Col, head.Row + 1),
+            Direction.Left => new GridPoint(head.Col - 1, head.Row),
+            Direction.Right => new GridPoint(head.Col + 1, head.Row),
+            _ => head,
+        };
+
+        // Wall collision
+        if (next.Col < 0 || next.Col >= GridCols || next.Row < 0 || next.Row >= GridRows)
+        {
+            Die();
+            return;
+        }
+
+        // Self collision
+        if (BodyContains(next))
+        {
+            Die();
+            return;
+        }
+
+        _body.AddFirst(next);
+
+        if (next == _food)
+        {
+            state.Score++;
+            _stepInterval = MathF.Max(MinStepInterval, _stepInterval - SpeedIncrement);
+            SpawnFood();
+        }
+        else
+        {
+            _body.RemoveLast();
+        }
+    }
+
+    // ── Draw ──────────────────────────────────────────────────────────────
+
+    public override void Draw(SKCanvas canvas, int width, int height)
+    {
+        canvas.Clear(BackgroundColor);
+
+        DrawGrid(canvas);
+        DrawFood(canvas);
+        DrawSnake(canvas);
+        DrawHud(canvas);
+    }
+
+    private static void DrawGrid(SKCanvas canvas)
+    {
+        for (int c = 1; c < GridCols; c++)
+        {
+            float x = c * CellSize;
+            canvas.DrawLine(x, 0, x, GameHeight, _gridPaint);
+        }
+        for (int r = 1; r < GridRows; r++)
+        {
+            float y = r * CellSize;
+            canvas.DrawLine(0, y, GameWidth, y, _gridPaint);
+        }
+    }
+
+    private void DrawFood(SKCanvas canvas)
+    {
+        _cellPaint.Color = FoodColor;
+        float fx = _food.Col * CellSize + 2f;
+        float fy = _food.Row * CellSize + 2f;
+        canvas.DrawRoundRect(fx, fy, CellSize - 4f, CellSize - 4f, 6f, 6f, _cellPaint);
+    }
+
+    private void DrawSnake(SKCanvas canvas)
+    {
+        bool isHead = true;
+        foreach (var seg in _body)
+        {
+            _cellPaint.Color = isHead ? SnakeHeadColor : SnakeBodyColor;
+            float sx = seg.Col * CellSize + 1f;
+            float sy = seg.Row * CellSize + 1f;
+            canvas.DrawRoundRect(sx, sy, CellSize - 2f, CellSize - 2f, 4f, 4f, _cellPaint);
+            isHead = false;
+        }
+    }
+
+    private void DrawHud(SKCanvas canvas)
+    {
+        _scoreText.Text = $"Score: {state.Score}";
+        canvas.Save(); canvas.Translate(10f, -6f); _scoreText.Draw(canvas); canvas.Restore();
+
+        if (state.HighScore > 0)
+        {
+            _highScoreText.Text = $"Best: {state.HighScore}";
+            canvas.Save(); canvas.Translate(GameWidth - 10f, -6f); _highScoreText.Draw(canvas); canvas.Restore();
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private void Die()
+    {
+        if (_gameOverShown) return;
+        _gameOverShown = true;
+
+        if (state.Score > state.HighScore)
+            state.HighScore = state.Score;
+
+        coordinator.PushOverlay<GameOverScreen>();
+    }
+
+    private bool BodyContains(GridPoint point)
+    {
+        foreach (var seg in _body)
+        {
+            if (seg == point)
+                return true;
+        }
+        return false;
+    }
+
+    private void SpawnFood()
+    {
+        GridPoint candidate;
+        do
+        {
+            candidate = new GridPoint(
+                Random.Shared.Next(GridCols),
+                Random.Shared.Next(GridRows));
+        }
+        while (BodyContains(candidate));
+
+        _food = candidate;
+    }
+
+    private static bool IsOpposite(Direction a, Direction b) =>
+        (a == Direction.Up && b == Direction.Down) ||
+        (a == Direction.Down && b == Direction.Up) ||
+        (a == Direction.Left && b == Direction.Right) ||
+        (a == Direction.Right && b == Direction.Left);
+}

--- a/src/Snake/PlayScreen.cs
+++ b/src/Snake/PlayScreen.cs
@@ -6,16 +6,15 @@ namespace SkiaSharpGames.Snake;
 
 internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordinator) : GameScreen
 {
-    private static readonly SKPaint _cellPaint = new() { IsAntialias = true };
-    private static readonly SKPaint _gridPaint = new() { Color = GridLineColor, StrokeWidth = 1f, IsAntialias = true };
+    private readonly Entity _grid = new() { Sprite = new GridSprite() };
+    private readonly SnakeEntity _snake = new();
+    private readonly FoodEntity _food = new();
 
     private readonly TextSprite _scoreText = new() { Size = 22f };
     private readonly TextSprite _highScoreText = new() { Size = 18f, Color = DimColor, Align = TextAlign.Right };
 
-    private readonly LinkedList<GridPoint> _body = new();
     private Direction _direction;
     private Direction _nextDirection;
-    private GridPoint _food;
     private float _stepTimer;
     private float _stepInterval;
     private bool _gameOverShown;
@@ -27,13 +26,7 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
         _stepTimer = 0f;
         _gameOverShown = false;
 
-        _body.Clear();
-        int startCol = GridCols / 2;
-        int startRow = GridRows / 2;
-        _body.AddFirst(new GridPoint(startCol, startRow));
-        _body.AddLast(new GridPoint(startCol - 1, startRow));
-        _body.AddLast(new GridPoint(startCol - 2, startRow));
-
+        _snake.Reset();
         _direction = Direction.Right;
         _nextDirection = Direction.Right;
 
@@ -59,9 +52,8 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
 
     public override void OnPointerDown(float x, float y)
     {
-        var head = _body.First!.Value;
-        float hx = head.Col * CellSize + CellSize / 2f;
-        float hy = head.Row * CellSize + CellSize / 2f;
+        float hx = _snake.X;
+        float hy = _snake.Y;
 
         float dx = x - hx;
         float dy = y - hy;
@@ -88,33 +80,15 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
         _stepTimer -= _stepInterval;
         _direction = _nextDirection;
 
-        var head = _body.First!.Value;
-        var next = _direction switch
-        {
-            Direction.Up => new GridPoint(head.Col, head.Row - 1),
-            Direction.Down => new GridPoint(head.Col, head.Row + 1),
-            Direction.Left => new GridPoint(head.Col - 1, head.Row),
-            Direction.Right => new GridPoint(head.Col + 1, head.Row),
-            _ => head,
-        };
+        _snake.Advance(_direction);
 
-        // Wall collision
-        if (next.Col < 0 || next.Col >= GridCols || next.Row < 0 || next.Row >= GridRows)
+        if (_snake.IsOutOfBounds() || _snake.HasSelfCollision())
         {
             Die();
             return;
         }
 
-        // Self collision
-        if (BodyContains(next))
-        {
-            Die();
-            return;
-        }
-
-        _body.AddFirst(next);
-
-        if (next == _food)
+        if (_snake.Head == _food.Cell)
         {
             state.Score++;
             _stepInterval = MathF.Max(MinStepInterval, _stepInterval - SpeedIncrement);
@@ -122,7 +96,7 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
         }
         else
         {
-            _body.RemoveLast();
+            _snake.TrimTail();
         }
     }
 
@@ -132,49 +106,11 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
     {
         canvas.Clear(BackgroundColor);
 
-        DrawGrid(canvas);
-        DrawFood(canvas);
-        DrawSnake(canvas);
-        DrawHud(canvas);
-    }
+        _grid.Draw(canvas);
+        _food.Draw(canvas);
+        _snake.Draw(canvas);
 
-    private static void DrawGrid(SKCanvas canvas)
-    {
-        for (int c = 1; c < GridCols; c++)
-        {
-            float x = c * CellSize;
-            canvas.DrawLine(x, 0, x, GameHeight, _gridPaint);
-        }
-        for (int r = 1; r < GridRows; r++)
-        {
-            float y = r * CellSize;
-            canvas.DrawLine(0, y, GameWidth, y, _gridPaint);
-        }
-    }
-
-    private void DrawFood(SKCanvas canvas)
-    {
-        _cellPaint.Color = FoodColor;
-        float fx = _food.Col * CellSize + 2f;
-        float fy = _food.Row * CellSize + 2f;
-        canvas.DrawRoundRect(fx, fy, CellSize - 4f, CellSize - 4f, 6f, 6f, _cellPaint);
-    }
-
-    private void DrawSnake(SKCanvas canvas)
-    {
-        bool isHead = true;
-        foreach (var seg in _body)
-        {
-            _cellPaint.Color = isHead ? SnakeHeadColor : SnakeBodyColor;
-            float sx = seg.Col * CellSize + 1f;
-            float sy = seg.Row * CellSize + 1f;
-            canvas.DrawRoundRect(sx, sy, CellSize - 2f, CellSize - 2f, 4f, 4f, _cellPaint);
-            isHead = false;
-        }
-    }
-
-    private void DrawHud(SKCanvas canvas)
-    {
+        // HUD
         _scoreText.Text = $"Score: {state.Score}";
         canvas.Save(); canvas.Translate(10f, -6f); _scoreText.Draw(canvas); canvas.Restore();
 
@@ -198,16 +134,6 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
         coordinator.PushOverlay<GameOverScreen>();
     }
 
-    private bool BodyContains(GridPoint point)
-    {
-        foreach (var seg in _body)
-        {
-            if (seg == point)
-                return true;
-        }
-        return false;
-    }
-
     private void SpawnFood()
     {
         GridPoint candidate;
@@ -217,9 +143,9 @@ internal sealed class PlayScreen(SnakeGameState state, IScreenCoordinator coordi
                 Random.Shared.Next(GridCols),
                 Random.Shared.Next(GridRows));
         }
-        while (BodyContains(candidate));
+        while (_snake.Occupies(candidate));
 
-        _food = candidate;
+        _food.PlaceAt(candidate);
     }
 
     private static bool IsOpposite(Direction a, Direction b) =>

--- a/src/Snake/SkiaSharpGames.Snake.csproj
+++ b/src/Snake/SkiaSharpGames.Snake.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>SkiaSharpGames.Snake</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" />
+    <PackageReference Include="SkiaSharp" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GameEngine\SkiaSharpGames.GameEngine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Snake/SnakeConstants.cs
+++ b/src/Snake/SnakeConstants.cs
@@ -1,0 +1,30 @@
+using SkiaSharp;
+
+namespace SkiaSharpGames.Snake;
+
+internal static class SnakeConstants
+{
+    // ── Grid ──────────────────────────────────────────────────────────────
+    public const int CellSize = 24;
+    public const int GridCols = 25;
+    public const int GridRows = 25;
+
+    // ── Game dimensions ───────────────────────────────────────────────────
+    public const int GameWidth = CellSize * GridCols;   // 600
+    public const int GameHeight = CellSize * GridRows;  // 600
+
+    // ── Timing ────────────────────────────────────────────────────────────
+    public const float InitialStepInterval = 0.15f;
+    public const float MinStepInterval = 0.06f;
+    public const float SpeedIncrement = 0.003f;
+
+    // ── Colours ───────────────────────────────────────────────────────────
+    public static readonly SKColor BackgroundColor = new(0x10, 0x14, 0x23);
+    public static readonly SKColor GridLineColor = new(0x1A, 0x1F, 0x30);
+    public static readonly SKColor SnakeHeadColor = new(0x5E, 0xD6, 0xFF);
+    public static readonly SKColor SnakeBodyColor = new(0x3A, 0xA8, 0xD0);
+    public static readonly SKColor FoodColor = new(0xFF, 0x7A, 0x7A);
+    public static readonly SKColor AccentColor = new(0x5E, 0xD6, 0xFF);
+    public static readonly SKColor DimColor = new(0xB8, 0xC2, 0xD9);
+    public static readonly SKColor DangerColor = new(0xFF, 0x7A, 0x7A);
+}

--- a/src/Snake/SnakeEntity.cs
+++ b/src/Snake/SnakeEntity.cs
@@ -11,7 +11,6 @@ internal sealed class SnakeEntity : Entity
     public SnakeEntity()
     {
         Sprite = new SnakeSprite { Body = _body };
-        Collider = new RectCollider { Width = CellSize, Height = CellSize };
     }
 
     public IReadOnlyCollection<GridPoint> Body => _body;
@@ -21,7 +20,6 @@ internal sealed class SnakeEntity : Entity
     public int Length => _body.Count;
 
     public new SnakeSprite Sprite { get => (SnakeSprite)base.Sprite!; init => base.Sprite = value; }
-    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
 
     /// <summary>Reset the snake to its starting position in the centre of the grid.</summary>
     public void Reset()
@@ -32,7 +30,6 @@ internal sealed class SnakeEntity : Entity
         _body.AddFirst(new GridPoint(startCol, startRow));
         _body.AddLast(new GridPoint(startCol - 1, startRow));
         _body.AddLast(new GridPoint(startCol - 2, startRow));
-        SyncPosition();
     }
 
     /// <summary>Advance the head in <paramref name="direction"/> and grow by one cell.</summary>
@@ -48,7 +45,6 @@ internal sealed class SnakeEntity : Entity
             _ => head,
         };
         _body.AddFirst(next);
-        SyncPosition();
     }
 
     /// <summary>Remove the tail segment (called when no food was eaten).</summary>
@@ -78,12 +74,5 @@ internal sealed class SnakeEntity : Entity
                 return true;
         }
         return false;
-    }
-
-    private void SyncPosition()
-    {
-        // Keep the entity position on the head for collider/world-space queries
-        X = Head.Col * CellSize + CellSize / 2f;
-        Y = Head.Row * CellSize + CellSize / 2f;
     }
 }

--- a/src/Snake/SnakeEntity.cs
+++ b/src/Snake/SnakeEntity.cs
@@ -1,0 +1,89 @@
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+/// <summary>The snake entity. Owns the body segment list and a sprite that renders it.</summary>
+internal sealed class SnakeEntity : Entity
+{
+    private readonly LinkedList<GridPoint> _body = new();
+
+    public SnakeEntity()
+    {
+        Sprite = new SnakeSprite { Body = _body };
+        Collider = new RectCollider { Width = CellSize, Height = CellSize };
+    }
+
+    public IReadOnlyCollection<GridPoint> Body => _body;
+
+    public GridPoint Head => _body.First!.Value;
+
+    public int Length => _body.Count;
+
+    public new SnakeSprite Sprite { get => (SnakeSprite)base.Sprite!; init => base.Sprite = value; }
+    public new RectCollider Collider { get => (RectCollider)base.Collider!; init => base.Collider = value; }
+
+    /// <summary>Reset the snake to its starting position in the centre of the grid.</summary>
+    public void Reset()
+    {
+        _body.Clear();
+        int startCol = GridCols / 2;
+        int startRow = GridRows / 2;
+        _body.AddFirst(new GridPoint(startCol, startRow));
+        _body.AddLast(new GridPoint(startCol - 1, startRow));
+        _body.AddLast(new GridPoint(startCol - 2, startRow));
+        SyncPosition();
+    }
+
+    /// <summary>Advance the head in <paramref name="direction"/> and grow by one cell.</summary>
+    public void Advance(Direction direction)
+    {
+        var head = Head;
+        var next = direction switch
+        {
+            Direction.Up => new GridPoint(head.Col, head.Row - 1),
+            Direction.Down => new GridPoint(head.Col, head.Row + 1),
+            Direction.Left => new GridPoint(head.Col - 1, head.Row),
+            Direction.Right => new GridPoint(head.Col + 1, head.Row),
+            _ => head,
+        };
+        _body.AddFirst(next);
+        SyncPosition();
+    }
+
+    /// <summary>Remove the tail segment (called when no food was eaten).</summary>
+    public void TrimTail() => _body.RemoveLast();
+
+    /// <summary>Returns true if any body segment occupies <paramref name="point"/>.</summary>
+    public bool Occupies(GridPoint point)
+    {
+        foreach (var seg in _body)
+            if (seg == point)
+                return true;
+        return false;
+    }
+
+    /// <summary>Returns true if the head has hit a wall.</summary>
+    public bool IsOutOfBounds() =>
+        Head.Col < 0 || Head.Col >= GridCols || Head.Row < 0 || Head.Row >= GridRows;
+
+    /// <summary>Returns true if the head collides with any other body segment.</summary>
+    public bool HasSelfCollision()
+    {
+        bool first = true;
+        foreach (var seg in _body)
+        {
+            if (first) { first = false; continue; }
+            if (seg == Head)
+                return true;
+        }
+        return false;
+    }
+
+    private void SyncPosition()
+    {
+        // Keep the entity position on the head for collider/world-space queries
+        X = Head.Col * CellSize + CellSize / 2f;
+        Y = Head.Row * CellSize + CellSize / 2f;
+    }
+}

--- a/src/Snake/SnakeGame.cs
+++ b/src/Snake/SnakeGame.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+using SkiaSharpGames.GameEngine;
+
+namespace SkiaSharpGames.Snake;
+
+public static class SnakeGame
+{
+    public static Game Create()
+    {
+        var builder = GameBuilder.CreateDefault();
+
+        builder.SetGameDimensions(SnakeConstants.GameWidth, SnakeConstants.GameHeight);
+        builder.Services.AddSingleton<SnakeGameState>();
+
+        builder.Screens
+               .Add<StartScreen>()
+               .Add<PlayScreen>()
+               .Add<GameOverScreen>();
+
+        builder.SetInitialScreen<StartScreen>();
+
+        return builder.Build();
+    }
+}

--- a/src/Snake/SnakeGameState.cs
+++ b/src/Snake/SnakeGameState.cs
@@ -1,0 +1,9 @@
+namespace SkiaSharpGames.Snake;
+
+/// <summary>Shared mutable state passed between the Snake play and end screens.</summary>
+internal sealed class SnakeGameState
+{
+    public int Score { get; set; }
+
+    public int HighScore { get; set; }
+}

--- a/src/Snake/SnakeSprite.cs
+++ b/src/Snake/SnakeSprite.cs
@@ -1,0 +1,31 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+/// <summary>Draws the full snake body as a chain of rounded-rect segments.</summary>
+internal sealed class SnakeSprite : Sprite
+{
+    private static readonly SKPaint _paint = new() { IsAntialias = true };
+
+    /// <summary>The body segments to draw (head first).</summary>
+    public LinkedList<GridPoint>? Body { get; set; }
+
+    public override void Draw(SKCanvas canvas)
+    {
+        if (!Visible || Alpha <= 0f || Body is null)
+            return;
+
+        bool isHead = true;
+        foreach (var seg in Body)
+        {
+            _paint.Color = (isHead ? SnakeHeadColor : SnakeBodyColor).WithAlpha((byte)(255 * Alpha));
+            float cx = seg.Col * CellSize + CellSize / 2f;
+            float cy = seg.Row * CellSize + CellSize / 2f;
+            canvas.DrawRoundRect(cx - CellSize / 2f + 1f, cy - CellSize / 2f + 1f,
+                                 CellSize - 2f, CellSize - 2f, 4f, 4f, _paint);
+            isHead = false;
+        }
+    }
+}

--- a/src/Snake/StartScreen.cs
+++ b/src/Snake/StartScreen.cs
@@ -1,0 +1,47 @@
+using SkiaSharp;
+using SkiaSharpGames.GameEngine;
+using static SkiaSharpGames.Snake.SnakeConstants;
+
+namespace SkiaSharpGames.Snake;
+
+internal sealed class StartScreen(IScreenCoordinator coordinator) : GameScreen
+{
+    private readonly TextSprite _title = new() { Text = "SNAKE", Size = 78f, Align = TextAlign.Center };
+    private readonly TextSprite _subtitle = new() { Text = "Eat, grow, survive", Size = 30f, Color = AccentColor, Align = TextAlign.Center };
+    private readonly TextSprite _instruction1 = new() { Text = "Arrow keys or WASD to steer", Size = 22f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _instruction2 = new() { Text = "Eat the red food to grow", Size = 22f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _instruction3 = new() { Text = "Don't hit the walls or yourself", Size = 22f, Color = DimColor, Align = TextAlign.Center };
+    private readonly TextSprite _startPrompt = new() { Text = "Click, tap, or press Space to start", Size = 24f, Align = TextAlign.Center };
+
+    // Decorative snake preview
+    private static readonly SKPaint _previewPaint = new() { IsAntialias = true };
+
+    public override void Draw(SKCanvas canvas, int width, int height)
+    {
+        canvas.Clear(BackgroundColor);
+
+        // Draw a small decorative snake icon
+        float cx = GameWidth / 2f;
+        _previewPaint.Color = SnakeHeadColor;
+        canvas.DrawRoundRect(cx - 12f, 140f, CellSize - 2, CellSize - 2, 4f, 4f, _previewPaint);
+        _previewPaint.Color = SnakeBodyColor;
+        for (int i = 1; i <= 4; i++)
+            canvas.DrawRoundRect(cx - 12f + i * CellSize, 140f, CellSize - 2, CellSize - 2, 4f, 4f, _previewPaint);
+
+        canvas.Save(); canvas.Translate(cx, 225f); _title.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 280f); _subtitle.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 345f); _instruction1.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 377f); _instruction2.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 409f); _instruction3.Draw(canvas); canvas.Restore();
+        canvas.Save(); canvas.Translate(cx, 474f); _startPrompt.Draw(canvas); canvas.Restore();
+    }
+
+    public override void OnPointerDown(float x, float y) =>
+        coordinator.TransitionTo<PlayScreen>(new DissolveTransition());
+
+    public override void OnKeyDown(string key)
+    {
+        if (key is " " or "Enter")
+            coordinator.TransitionTo<PlayScreen>(new DissolveTransition());
+    }
+}


### PR DESCRIPTION
Classic grid-based Snake game added to the gallery.

## What's new

- **`src/Snake/`** — New `SkiaSharpGames.Snake` class library with 9 source files
- **Gameplay** — 25×25 grid, arrow key/WASD/tap controls, food eating, progressive speed increase, wall & self-collision
- **Screens** — Start → Play → GameOver overlay, following existing patterns
- **High score** tracking across retries within a session

## Integration

- Blazor page at `/games/snake`
- Keyed DI service registration in `Program.cs`
- Solution file and BlazorApp project reference
- Gallery card with 🐍 emoji on Home.razor
- Gameplay docs at `docs/games/snake.md`
- README updates (games table, project structure, docs links)